### PR TITLE
⬆️ DCS-1374: update hmpps-circle-orb version to 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.8
+  hmpps: ministryofjustice/hmpps@3.12
   slack: circleci/slack@4.4.2
 
 parameters:


### PR DESCRIPTION
⬆️ DCS-1374: update hmpps-circle-orb version to 3.12