### PR TITLE
DCS-1368 CSP fix to google analytics script

### DIFF
--- a/assets/js/googleAnalytics.js
+++ b/assets/js/googleAnalytics.js
@@ -1,0 +1,9 @@
+const el = document.getElementById('google-analytics')
+
+window.dataLayer = window.dataLayer || []
+function gtag() {
+  dataLayer.push(arguments)
+}
+gtag('js', new Date())
+
+gtag('config', `${el.dataset.analytics}`)

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -32,6 +32,7 @@ export default function setUpWebSecurity(): Router {
             'code.jquery.com',
             "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
           ],
+          imgSrc: ["'self'", 'www.googletagmanager.com', 'www.google-analytics.com', 'https://code.jquery.com'],
           connectSrc: ["'self'", 'www.googletagmanager.com', 'www.google-analytics.com'],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -12,13 +12,7 @@
   {% if googleAnalyticsId %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="{{'https://www.googletagmanager.com/gtag/js?id=' + googleAnalyticsId}}"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', '{{googleAnalyticsId}}');
-    </script>
+    <script src="/assets/js/googleAnalytics.js" id='google-analytics' data-analytics={{googleAnalyticsId}}></script>
   {% endif %}
 
   {% if tagManagerContainerId %}


### PR DESCRIPTION
Extracted out inline script for google analytics as it was being blocked by the Helmet content security policy middleware. Also added missing content security policy imgSrc directives. 