### PR TITLE
DCS-1326 padding removed so that the title 

### DIFF
--- a/server/views/pages/bookedtoday/arrivals/confirmArrival.njk
+++ b/server/views/pages/bookedtoday/arrivals/confirmArrival.njk
@@ -23,7 +23,7 @@
             </div>
             <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-margin-top-4 govuk-!-margin-bottom-8 flex" >
                 <div class="column-width-40 govuk-!-padding-right-9">
-                    <h2 class="govuk-heading-m govuk-!-padding-right-9">Details from Person Escort Record</h2>
+                    <h2 class="govuk-heading-m">Details from Person Escort Record</h2>
                     <div class = "prisoner-record-detail prisoner-head">
                         {{ prisonerSummaryDetail(data, "per-record" ) }}
                     </div>


### PR DESCRIPTION
'Details from Person Escort Record' is on one line

Discussion with designer confirms the 40/60 column widths are okay