### PR TITLE
DCS-1445: 🔧 align Dockerfile with template project to discourage circle caching image dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,17 @@ RUN addgroup --gid 2000 --system appgroup && \
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get upgrade -y
+    apt-get upgrade -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Stage: build assets
 FROM base as build
 ARG BUILD_NUMBER
 ARG GIT_REF
 
-RUN apt-get install -y make python g++
+RUN apt-get update && \
+    apt-get install -y make python g++
 
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit


### PR DESCRIPTION
It looks like CircleCI is always pulling a cache when we run the apt update / upgrade commands, meaning new builds don't pull through the latest versions of packages.

This is an issue since we have security alerts pinging and can't seem to get rid of them.

Not entirely sure on the actual issue here, but the assumption is our Dockerfile is incorrect ( I think maybe having a rm -rf will stop it caching all the commands? ). But I've aligned it more with how the template project does things in hopes that fixes it. Noticed most of our projects build these in different ways, so hard to tell what exactly it is causing the issue.