### PR TITLE
DCS-1487 Fix issue with court transfers

### DIFF
--- a/integration_tests/integration/bookedtoday/arrivals/courtreturns/courtReturn.spec.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/courtreturns/courtReturn.spec.ts
@@ -44,7 +44,7 @@ context('Confirm court return added To roll', () => {
     Page.verifyOnPage(ChoosePrisonerPage)
 
     cy.task('getCourtReturnConfirmationRequest', expectedArrival.id).then(request => {
-      expect(request).to.deep.equal({ prisonId: 'MDI', prisonNumber: 'G0013AB' })
+      expect(request).to.deep.equal({ prisonId: 'MDI', prisonNumber: 'A1234BC' })
     })
   })
 })

--- a/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
@@ -1,4 +1,4 @@
-import type { Arrival } from 'welcome'
+import { Arrival, GenderKeys, PrisonerDetails } from 'welcome'
 import type { Express } from 'express'
 import request from 'supertest'
 import cheerio from 'cheerio'
@@ -13,7 +13,16 @@ const expectedArrivalsService = new ExpectedArrivalsService(null, null) as jest.
 let app: Express
 const raiseAnalyticsEvent = jest.fn() as RaiseAnalyticsEvent
 
-const courtReturn = {
+const courtReturn: PrisonerDetails = {
+  firstName: 'Jim',
+  lastName: 'Smith',
+  dateOfBirth: '1973-01-08',
+  prisonNumber: 'A1234AB',
+  pncNumber: '01/98644M',
+  sex: GenderKeys.MALE,
+}
+
+const arrival: Arrival = {
   firstName: 'Jim',
   lastName: 'Smith',
   dateOfBirth: '1973-01-08',
@@ -22,12 +31,14 @@ const courtReturn = {
   date: '2021-10-13',
   fromLocation: 'Some court',
   fromLocationType: 'COURT',
-} as Arrival
+  isCurrentPrisoner: true,
+}
 
 beforeEach(() => {
   app = appWithAllRoutes({ services: { expectedArrivalsService, raiseAnalyticsEvent }, roles: [Role.PRISON_RECEPTION] })
   config.confirmEnabled = true
-  expectedArrivalsService.getArrival.mockResolvedValue(courtReturn)
+  expectedArrivalsService.getPrisonerDetailsForArrival.mockResolvedValue(courtReturn)
+  expectedArrivalsService.getArrival.mockResolvedValue(arrival)
   expectedArrivalsService.confirmCourtReturn.mockResolvedValue({
     prisonNumber: 'A1234AB',
     location: 'Reception',
@@ -50,7 +61,7 @@ describe('checkCourtReturnController', () => {
         .get('/prisoners/12345-67890/check-court-return')
         .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(() => {
-          expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('12345-67890')
+          expect(expectedArrivalsService.getPrisonerDetailsForArrival).toHaveBeenCalledWith('12345-67890')
         })
     })
 

--- a/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.ts
@@ -10,7 +10,7 @@ export default class CheckCourtReturnController {
   public checkCourtReturn(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
-      const data = await this.expectedArrivalsService.getArrival(id)
+      const data = await this.expectedArrivalsService.getPrisonerDetailsForArrival(id)
       return res.render('pages/bookedtoday/arrivals/courtreturns/checkCourtReturn.njk', { data, id })
     }
   }
@@ -20,7 +20,8 @@ export default class CheckCourtReturnController {
       const { id } = req.params
       const { username } = req.user
       const { activeCaseLoadId } = res.locals.user
-      const data = await this.expectedArrivalsService.getArrival(id)
+      const arrival = await this.expectedArrivalsService.getArrival(id)
+      const data = await this.expectedArrivalsService.getPrisonerDetailsForArrival(id)
 
       const arrivalResponse = await this.expectedArrivalsService.confirmCourtReturn(
         username,
@@ -36,14 +37,14 @@ export default class CheckCourtReturnController {
       req.flash('prisoner', {
         firstName: data.firstName,
         lastName: data.lastName,
-        prisonNumber: arrivalResponse.prisonNumber,
+        prisonNumber: data.prisonNumber,
         location: arrivalResponse.location,
       })
 
       this.raiseAnalyticsEvent(
         'Add to the establishment roll',
         'Confirmed court return returned',
-        `AgencyId: ${activeCaseLoadId}, From: ${data.fromLocation}, Type: ${data.fromLocationType},`,
+        `AgencyId: ${activeCaseLoadId}, From: ${arrival.fromLocation}, Type: ${arrival.fromLocationType},`,
         req.hostname
       )
 

--- a/server/routes/bookedtoday/arrivals/sexController.test.ts
+++ b/server/routes/bookedtoday/arrivals/sexController.test.ts
@@ -55,7 +55,7 @@ describe('/sex', () => {
       }
     )
 
-    it.each([{ sex: GenderKeys.MALE }, { sex: GenderKeys.FEMALE }])(
+    it.each([{ sex: GenderKeys.MALE }, { sex: 'M' }, { sex: GenderKeys.FEMALE }, { sex: 'F' }])(
       'should render /imprisonment-status page when Arrival gender is MALE or FEMALE',
       ({ sex }) => {
         signedCookiesProvider.mockReturnValue({

--- a/server/routes/bookedtoday/arrivals/sexController.ts
+++ b/server/routes/bookedtoday/arrivals/sexController.ts
@@ -8,10 +8,10 @@ export default class SexController {
 
       const data = State.newArrival.get(req)
 
-      const genderValue = this.convertGenderKeyToValue(data.sex)
+      const sex = this.normaliseToNomisValue(data.sex)
 
-      if (genderValue) {
-        State.newArrival.update(req, res, { sex: genderValue })
+      if (sex) {
+        State.newArrival.update(req, res, { sex })
         return res.redirect(`/prisoners/${id}/imprisonment-status`)
       }
 
@@ -38,9 +38,9 @@ export default class SexController {
     }
   }
 
-  private convertGenderKeyToValue(value: string): string {
-    if (value?.toUpperCase() === 'MALE') return 'M'
-    if (value?.toUpperCase() === 'FEMALE') return 'F'
+  private normaliseToNomisValue(value: string): string {
+    if (['MALE', 'M'].includes(value?.toUpperCase())) return 'M'
+    if (['FEMALE', 'F'].includes(value?.toUpperCase())) return 'F'
     return null
   }
 }

--- a/server/routes/bookedtoday/transfers/confirmTransferAddedToRollController.test.ts
+++ b/server/routes/bookedtoday/transfers/confirmTransferAddedToRollController.test.ts
@@ -44,7 +44,7 @@ describe('GET /view', () => {
     flashProvider.mockReturnValue([{ firstName: 'Jim', lastName: 'Smith', location: 'Reception' }])
     return request(app)
       .get('/prisoners/A1234AB/confirm-transfer')
-      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect('Content-Type', /text\/html/)
       .expect(() => {
         expect(flashProvider).toHaveBeenCalledWith('prisoner')
       })

--- a/server/services/expectedArrivalsService.test.ts
+++ b/server/services/expectedArrivalsService.test.ts
@@ -252,6 +252,22 @@ describe('Expected arrivals service', () => {
     })
   })
 
+  describe('getPrisonDetailsForArrival', () => {
+    it('Calls upstream service correctly', async () => {
+      const result = await service.getPrisonerDetailsForArrival('12345-67890')
+
+      expect(WelcomeClientFactory).toBeCalledWith(token)
+      expect(welcomeClient.getArrival).toBeCalledWith('12345-67890')
+      expect(result).toStrictEqual({
+        dateOfBirth: '1973-01-08',
+        firstName: 'James',
+        lastName: 'Smyth',
+        pncNumber: '99/98644M',
+        prisonNumber: 'A1234AB',
+      })
+    })
+  })
+
   describe('createOffenderRecordAndBooking', () => {
     const newOffender: NewOffenderBooking = {
       firstName: 'Jim',

--- a/server/services/expectedArrivalsService.ts
+++ b/server/services/expectedArrivalsService.ts
@@ -10,6 +10,7 @@ import moment, { type Moment } from 'moment'
 import type { Readable } from 'stream'
 import { groupBy, compareByFullName } from '../utils/utils'
 import type { RestClientBuilder, WelcomeClient, HmppsAuthClient } from '../data'
+import logger from '../../logger'
 
 export enum LocationType {
   COURT = 'COURT',
@@ -54,6 +55,15 @@ export default class ExpectedArrivalsService {
   public async getArrival(id: string): Promise<Arrival> {
     const token = await this.hmppsAuthClient.getSystemClientToken()
     return this.welcomeClientFactory(token).getArrival(id)
+  }
+
+  public async getPrisonerDetailsForArrival(id: string): Promise<PrisonerDetails> {
+    const token = await this.hmppsAuthClient.getSystemClientToken()
+    const arrival = await this.welcomeClientFactory(token).getArrival(id)
+    if (arrival.potentialMatches.length > 1) {
+      logger.warn(`multiple matches for move: ${id}`)
+    }
+    return arrival.potentialMatches[0]
   }
 
   public async createOffenderRecordAndBooking(


### PR DESCRIPTION
Now we no longer merge in matching prisoners into the top level arrival
details we fail to show prisoner info on the court return pages.

This fixes that by retrieving the appropriate prisoner record.

It also fixes a minor issue with the sex controller, where if you
navigated through and back again and through the sex controller it
would ask to provide the arrivals sex (even though it initially was
present)