### PR TITLE
DCS-1499 corrected search-for-existing-record result pages url paths

### DIFF
--- a/integration_tests/pages/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.ts
+++ b/integration_tests/pages/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.ts
@@ -6,7 +6,7 @@ export default class MultipleMatchingRecordsFoundPage extends Page {
   }
 
   static goTo(id: string): MultipleMatchingRecordsFoundPage {
-    cy.visit(`/prisoners/${id}/search-for-different-existing-record/possible-records-found`)
+    cy.visit(`/prisoners/${id}/search-for-existing-record/possible-records-found`)
     return Page.verifyOnPage(MultipleMatchingRecordsFoundPage)
   }
 

--- a/server/routes/bookedtoday/arrivals/searchforexisting/index.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/index.ts
@@ -54,7 +54,7 @@ export default function routes(services: Services): Router {
   const singleExistingRecordFoundController = new SingleExistingRecordFoundController()
   get('/record-found', [checkNewArrivalPresent, checkSearchDetailsPresent, singleExistingRecordFoundController.view()])
 
-  const noExistingRecordsFoundController = new NoExistingRecordsFoundController(services.expectedArrivalsService)
+  const noExistingRecordsFoundController = new NoExistingRecordsFoundController()
   get('/no-record-found', [noExistingRecordsFoundController.view()])
 
   router.use(searchRoutes(services))

--- a/server/routes/bookedtoday/arrivals/searchforexisting/index.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/index.ts
@@ -23,7 +23,7 @@ export default function routes(services: Services): Router {
 
   const get = (path: string, handlers: RequestHandler[]) =>
     router.get(
-      `/prisoners/:id/search-for-different-existing-record${path}`,
+      `/prisoners/:id/search-for-existing-record${path}`,
       authorisationForUrlMiddleware([Role.PRISON_RECEPTION]),
       [
         redirectIfDisabledMiddleware(config.confirmNoIdentifiersEnabled),
@@ -33,7 +33,7 @@ export default function routes(services: Services): Router {
 
   const post = (path: string, handlers: RequestHandler[]) =>
     router.post(
-      `/prisoners/:id/search-for-different-existing-record${path}`,
+      `/prisoners/:id/search-for-existing-record${path}`,
       authorisationForUrlMiddleware([Role.PRISON_RECEPTION]),
       [
         redirectIfDisabledMiddleware(config.confirmNoIdentifiersEnabled),

--- a/server/routes/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFoundController.test.ts
@@ -52,7 +52,7 @@ describe('possible records found', () => {
   describe('view', () => {
     it('should get search details from state', () => {
       return request(app)
-        .get('/prisoners/12345-67890/search-for-different-existing-record/possible-records-found')
+        .get('/prisoners/12345-67890/search-for-existing-record/possible-records-found')
         .expect(() => {
           expect(signedCookiesProvider).toHaveBeenCalledTimes(1)
         })
@@ -60,7 +60,7 @@ describe('possible records found', () => {
 
     it('should call service method correctly', () => {
       return request(app)
-        .get('/prisoners/12345-67890/search-for-different-existing-record/possible-records-found')
+        .get('/prisoners/12345-67890/search-for-existing-record/possible-records-found')
         .expect(() => {
           expect(expectedArrivalsService.getMatchingRecords).toHaveBeenCalledWith(searchDetails)
         })
@@ -68,7 +68,7 @@ describe('possible records found', () => {
 
     it('should render page correctly', () => {
       return request(app)
-        .get('/prisoners/12345-67890/search-for-different-existing-record/possible-records-found')
+        .get('/prisoners/12345-67890/search-for-existing-record/possible-records-found')
         .expect(200)
         .expect('Content-Type', /html/)
         .expect(res => {
@@ -81,10 +81,10 @@ describe('possible records found', () => {
   describe('submit', () => {
     it('should redirect if errors', () => {
       return request(app)
-        .post('/prisoners/12345-67890/search-for-different-existing-record/possible-records-found')
+        .post('/prisoners/12345-67890/search-for-existing-record/possible-records-found')
         .send()
         .expect(302)
-        .expect('Location', '/prisoners/12345-67890/search-for-different-existing-record/possible-records-found')
+        .expect('Location', '/prisoners/12345-67890/search-for-existing-record/possible-records-found')
         .expect(() => {
           expect(flashProvider).toHaveBeenCalledWith('errors', [
             {
@@ -97,7 +97,7 @@ describe('possible records found', () => {
 
     it('should redirect to /sex page if no errors', () => {
       return request(app)
-        .post('/prisoners/12345-67890/search-for-different-existing-record/possible-records-found')
+        .post('/prisoners/12345-67890/search-for-existing-record/possible-records-found')
         .send(potentialMatches[0])
         .expect(302)
         .expect('Location', '/prisoners/12345-67890/sex')

--- a/server/routes/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFoundController.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFoundController.ts
@@ -32,7 +32,7 @@ export default class MultipleExistingRecordsFoundController {
 
       if (req.errors) {
         req.flash('errors', req.body)
-        return res.redirect(`/prisoners/${id}/search-for-different-existing-record/possible-records-found`)
+        return res.redirect(`/prisoners/${id}/search-for-existing-record/possible-records-found`)
       }
 
       const { prisonNumber } = req.body

--- a/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.test.ts
@@ -1,36 +1,24 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import cheerio from 'cheerio'
-import { type Arrival, GenderKeys } from 'welcome'
-import { appWithAllRoutes } from '../../../__testutils/appSetup'
-import ExpectedArrivalsService, { LocationType } from '../../../../services/expectedArrivalsService'
+import { appWithAllRoutes, signedCookiesProvider } from '../../../__testutils/appSetup'
 import Role from '../../../../authentication/role'
 import config from '../../../../config'
-
-jest.mock('../../../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(null, null) as jest.Mocked<ExpectedArrivalsService>
 
 let app: Express
 
 beforeEach(() => {
   config.confirmNoIdentifiersEnabled = true
-  app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [Role.PRISON_RECEPTION] })
-  expectedArrivalsService.getArrival.mockResolvedValue({
-    id: '1111-2222-3333-4444',
-    firstName: 'James',
-    lastName: 'Smyth',
-    dateOfBirth: '1973-01-08',
-    prisonNumber: 'A1234AB',
-    pncNumber: '01/98644M',
-    date: '2021-09-01',
-    fromLocation: 'Reading',
-    moveType: 'PRISON_REMAND',
-    fromLocationType: LocationType.COURT,
-    gender: GenderKeys.MALE,
-    isCurrentPrisoner: false,
-    potentialMatches: [],
-  } as Arrival)
+  app = appWithAllRoutes({ roles: [Role.PRISON_RECEPTION] })
+  signedCookiesProvider.mockReturnValue({
+    'search-details': {
+      firstName: 'James',
+      lastName: 'Smyth',
+      dateOfBirth: '1973-01-08',
+      prisonNumber: undefined,
+      pncNumber: undefined,
+    },
+  })
 })
 
 afterEach(() => {
@@ -44,6 +32,14 @@ describe('GET /view', () => {
       .get('/prisoners/12345-67890/search-for-existing-record/no-record-found')
       .expect(302)
       .expect('Location', '/autherror')
+  })
+
+  it('should get details from state', () => {
+    return request(app)
+      .get('/prisoners/12345-67890/search-for-existing-record/no-record-found')
+      .expect(() => {
+        expect(signedCookiesProvider).toHaveBeenCalledTimes(1)
+      })
   })
 
   it('should display correct page heading', () => {

--- a/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.test.ts
@@ -55,8 +55,6 @@ describe('GET /view', () => {
         expect($('h1').text()).toContain('This person does not have an existing prisoner record')
         expect($('.data-qa-per-record-prisoner-name').text()).toContain('James Smyth')
         expect($('.data-qa-per-record-dob').text()).toContain('8 January 1973')
-        expect($('.data-qa-per-record-prison-number').text()).toContain('A1234AB')
-        expect($('.data-qa-per-record-pnc-number').text()).toContain('01/98644M')
         expect($('[data-qa = "continue"]').text()).toContain('Continue')
       })
   })

--- a/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.test.ts
@@ -41,14 +41,14 @@ describe('GET /view', () => {
   it('should redirect to authentication error page for non reception users', () => {
     app = appWithAllRoutes({ roles: [] })
     return request(app)
-      .get('/prisoners/12345-67890/search-for-different-existing-record/no-record-found')
+      .get('/prisoners/12345-67890/search-for-existing-record/no-record-found')
       .expect(302)
       .expect('Location', '/autherror')
   })
 
   it('should display correct page heading', () => {
     return request(app)
-      .get('/prisoners/12345-67890/search-for-different-existing-record/no-record-found')
+      .get('/prisoners/12345-67890/search-for-existing-record/no-record-found')
       .expect('Content-Type', 'text/html; charset=utf-8')
       .expect(res => {
         const $ = cheerio.load(res.text)

--- a/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.ts
@@ -1,19 +1,17 @@
 import type { RequestHandler } from 'express'
-import { ExpectedArrivalsService } from '../../../../services'
+import { State } from '../state'
 
 export default class NoMatchingRecordsFoundController {
-  public constructor(private readonly expectedArrivalsService: ExpectedArrivalsService) {}
-
   public view(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
-      const data = await this.expectedArrivalsService.getArrival(id)
+      const searchData = State.searchDetails.get(req)
 
       return res.render('pages/bookedtoday/arrivals/searchforexisting/noExistingRecordsFound.njk', {
         arrival: {
-          firstName: data.firstName,
-          lastName: data.lastName,
-          dateOfBirth: data.dateOfBirth,
+          firstName: searchData.firstName,
+          lastName: searchData.lastName,
+          dateOfBirth: searchData.dateOfBirth,
         },
         id,
       })

--- a/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/noExistingRecordsFoundController.ts
@@ -9,7 +9,14 @@ export default class NoMatchingRecordsFoundController {
       const { id } = req.params
       const data = await this.expectedArrivalsService.getArrival(id)
 
-      return res.render('pages/bookedtoday/arrivals/searchforexisting/noExistingRecordsFound.njk', { data })
+      return res.render('pages/bookedtoday/arrivals/searchforexisting/noExistingRecordsFound.njk', {
+        arrival: {
+          firstName: data.firstName,
+          lastName: data.lastName,
+          dateOfBirth: data.dateOfBirth,
+        },
+        id,
+      })
     }
   }
 }

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
@@ -203,7 +203,7 @@ describe('POST /search-for-existing-record', () => {
     return request(app)
       .post('/prisoners/12345-67890/search-for-existing-record')
       .expect(302)
-      .expect('Location', '/prisoners/12345-67890/search-for-different-existing-record/possible-records-found')
+      .expect('Location', '/prisoners/12345-67890/search-for-existing-record/possible-records-found')
   })
 
   it('should set new-arrival state and redirect to /record-found when one existing potential record found', () => {
@@ -231,7 +231,7 @@ describe('POST /search-for-existing-record', () => {
           pncNumber: '88/98544M',
         })
       })
-      .expect('Location', '/prisoners/12345-67890/search-for-different-existing-record/record-found')
+      .expect('Location', '/prisoners/12345-67890/search-for-existing-record/record-found')
   })
 
   it('should redirect to /no-record-found when no existing potential records found', () => {
@@ -241,6 +241,6 @@ describe('POST /search-for-existing-record', () => {
     return request(app)
       .post('/prisoners/12345-67890/search-for-existing-record')
       .expect(302)
-      .expect('Location', '/prisoners/12345-67890/search-for-different-existing-record/no-record-found')
+      .expect('Location', '/prisoners/12345-67890/search-for-existing-record/no-record-found')
   })
 })

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.ts
@@ -48,7 +48,7 @@ export default class SearchForExistingRecordController {
       const potentialMatches = await this.expectedArrivalsService.getMatchingRecords(searchData)
 
       if (potentialMatches.length > 1) {
-        return res.redirect(`/prisoners/${id}/search-for-different-existing-record/possible-records-found`)
+        return res.redirect(`/prisoners/${id}/search-for-existing-record/possible-records-found`)
       }
       if (potentialMatches.length === 1) {
         const match = potentialMatches[0]
@@ -61,9 +61,9 @@ export default class SearchForExistingRecordController {
           pncNumber: match.pncNumber,
         })
 
-        return res.redirect(`/prisoners/${id}/search-for-different-existing-record/record-found`)
+        return res.redirect(`/prisoners/${id}/search-for-existing-record/record-found`)
       }
-      return res.redirect(`/prisoners/${id}/search-for-different-existing-record/no-record-found`)
+      return res.redirect(`/prisoners/${id}/search-for-existing-record/no-record-found`)
     }
   }
 }

--- a/server/routes/bookedtoday/arrivals/searchforexisting/singleExistingRecordFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/singleExistingRecordFoundController.test.ts
@@ -45,7 +45,7 @@ describe('GET /view', () => {
 
   it('should get details from state', () => {
     return request(app)
-      .get('/prisoners/12345-67890/search-for-existing-record/records-found')
+      .get('/prisoners/12345-67890/search-for-existing-record/record-found')
       .expect(() => {
         expect(signedCookiesProvider).toHaveBeenCalledTimes(1)
       })

--- a/server/routes/bookedtoday/arrivals/searchforexisting/singleExistingRecordFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/singleExistingRecordFoundController.test.ts
@@ -38,14 +38,14 @@ describe('GET /view', () => {
   it('should redirect to authentication error page for non reception users', () => {
     app = appWithAllRoutes({ roles: [] })
     return request(app)
-      .get('/prisoners/12345-67890/search-for-different-existing-record/record-found')
+      .get('/prisoners/12345-67890/search-for-existing-record/record-found')
       .expect(302)
       .expect('Location', '/autherror')
   })
 
   it('should get details from state', () => {
     return request(app)
-      .get('/prisoners/12345-67890/search-for-different-existing-record/records-found')
+      .get('/prisoners/12345-67890/search-for-existing-record/records-found')
       .expect(() => {
         expect(signedCookiesProvider).toHaveBeenCalledTimes(1)
       })
@@ -53,7 +53,7 @@ describe('GET /view', () => {
 
   it('should display correct page content', () => {
     return request(app)
-      .get('/prisoners/12345-67890/search-for-different-existing-record/record-found')
+      .get('/prisoners/12345-67890/search-for-existing-record/record-found')
       .expect('Content-Type', 'text/html; charset=utf-8')
       .expect(res => {
         const $ = cheerio.load(res.text)

--- a/server/views/pages/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.njk
+++ b/server/views/pages/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.njk
@@ -40,7 +40,7 @@
                     </div>
 
                     <div class="govuk-grid-column-one-half column-width-60 border-left-grey govuk-!-padding-left-9 govuk-!-padding-right-0 ">
-                        <form method="post" action="/prisoners/{{ data.id }}/search-for-different-existing-record/possible-records-found">
+                        <form method="post" action="/prisoners/{{ data.id }}/search-for-existing-record/possible-records-found">
                             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                             <div class="govuk-form-group {{ formGroupError }}" >
                                 <h2 class="govuk-heading-m">Select the correct existing record</h2> 

--- a/server/views/pages/bookedtoday/arrivals/searchforexisting/noExistingRecordsFound.njk
+++ b/server/views/pages/bookedtoday/arrivals/searchforexisting/noExistingRecordsFound.njk
@@ -15,7 +15,7 @@
             </div>
             <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-margin-top-4 govuk-!-margin-bottom-8 flex" >
                 <div class="column-width-40 govuk-!-padding-right-9">
-                    <h2 class="govuk-heading-m">Details from Person Escort Record</h2>
+                    <h2 class="govuk-heading-m">Personal details</h2>
                     <div class = "prisoner-record-detail prisoner-head">
                         {{ prisonerSummaryDetail(data, "per-record" ) }}
                     </div>

--- a/server/views/pages/bookedtoday/arrivals/searchforexisting/noExistingRecordsFound.njk
+++ b/server/views/pages/bookedtoday/arrivals/searchforexisting/noExistingRecordsFound.njk
@@ -10,21 +10,21 @@
                 <div class="govuk-grid-column-two-thirds">
                     <span class="govuk-caption-xl"> Confirm a prisoner's arrival </span>
                     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">This person does not have an existing prisoner record</h1>
-                    <p> {{ data.firstName }} {{ data.lastName }} does not have an existing prisoner record. A new record will be created when they are added to the establishment roll. </p>
+                    <p> {{ arrival.firstName }} {{ arrival.lastName }} does not have an existing prisoner record. A new record will be created when they are added to the establishment roll. </p>
                 </div>
             </div>
             <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-margin-top-4 govuk-!-margin-bottom-8 flex" >
                 <div class="column-width-40 govuk-!-padding-right-9">
                     <h2 class="govuk-heading-m">Personal details</h2>
                     <div class = "prisoner-record-detail prisoner-head">
-                        {{ prisonerSummaryDetail(data, "per-record" ) }}
+                        {{ prisonerSummaryDetail(arrival, "per-record" ) }}
                     </div>
                 </div>
             </div> 
             <div>   
                 {{ govukButton({
                     classes: "govuk-button govuk-!-margin-bottom-6",
-                    href: "/prisoners/" + data.id + "/review-per-details",
+                    href: "/prisoners/" + id + "/review-per-details",
                     text: "Continue",
                     attributes: {'data-qa': 'continue'}
                 }) }}

--- a/server/views/pages/bookedtoday/arrivals/searchforexisting/singleExistingRecordFound.njk
+++ b/server/views/pages/bookedtoday/arrivals/searchforexisting/singleExistingRecordFound.njk
@@ -13,7 +13,7 @@
             </div>
             <div class="govuk-grid-row govuk-!-padding-left-3 govuk-!-margin-top-4 govuk-!-margin-bottom-8 flex" >
                 <div class="column-width-40 govuk-!-padding-right-9">
-                    <h2 class="govuk-heading-m">Details from Person Escort Record</h2>
+                    <h2 class="govuk-heading-m">Personal details</h2>
                     <div class = "prisoner-record-detail prisoner-head">
                         {{ prisonerSummaryDetail(arrival, "per-record" ) }}
                     </div>


### PR DESCRIPTION
Updated no match page content with Personal details subheading for arrival details. We now get these details from state and make sure we only display name and dob:
<img width="1199" alt="Screenshot 2022-03-15 at 14 24 21" src="https://user-images.githubusercontent.com/48809053/158399722-7f802f87-e395-486f-8bf9-1651fa042341.png">

Updated single match page content with Personal details subheading for arrival details. 
<img width="1192" alt="Screenshot 2022-03-15 at 14 25 42" src="https://user-images.githubusercontent.com/48809053/158400386-cd36c5b3-c2c7-43f6-8924-38e97403c5a8.png">

Also updated url path for match result pages which follow the Search for an existing prisoner record page.