### PR TITLE
DCS-1503 clear out new arrival state after no result or multiple results found

### DIFF
--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/changeDateOfBirthController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/changeDateOfBirthController.test.ts
@@ -112,17 +112,13 @@ describe('POST /search-for-existing-record/change-date-of-birth', () => {
       .expect(302)
       .expect('Location', '/prisoners/12345-67890/search-for-existing-record')
       .expect(res => {
-        expect(res.header['set-cookie'][0]).toContain(
-          encodeURIComponent(
-            JSON.stringify({
-              firstName: 'James',
-              lastName: 'Smyth',
-              dateOfBirth: '2003-02-01',
-              prisonNumber: 'A1234AB',
-              pncNumber: '99/98644M',
-            })
-          )
-        )
+        expectSettingCookie(res, 'search-details').toStrictEqual({
+          firstName: 'James',
+          lastName: 'Smyth',
+          dateOfBirth: '2003-02-01',
+          prisonNumber: 'A1234AB',
+          pncNumber: '99/98644M',
+        })
       })
   })
 

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/changeNameController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/changeNameController.test.ts
@@ -4,6 +4,7 @@ import cheerio from 'cheerio'
 import { appWithAllRoutes, signedCookiesProvider, flashProvider } from '../../../../__testutils/appSetup'
 import Role from '../../../../../authentication/role'
 import config from '../../../../../config'
+import { expectSettingCookie } from '../../../../__testutils/requestTestUtils'
 
 let app: Express
 
@@ -83,17 +84,13 @@ describe('POST /search-for-existing-record/change-name', () => {
       .post('/prisoners/12345-67890/search-for-existing-record/change-name')
       .send({ firstName: 'Bob', lastName: 'Smith' })
       .expect(res => {
-        expect(res.header['set-cookie'][0]).toContain(
-          encodeURIComponent(
-            JSON.stringify({
-              firstName: 'Bob',
-              lastName: 'Smith',
-              dateOfBirth: '1973-01-08',
-              prisonNumber: 'A1234AB',
-              pncNumber: '99/98644M',
-            })
-          )
-        )
+        expectSettingCookie(res, 'search-details').toStrictEqual({
+          firstName: 'Bob',
+          lastName: 'Smith',
+          dateOfBirth: '1973-01-08',
+          prisonNumber: 'A1234AB',
+          pncNumber: '99/98644M',
+        })
       })
   })
 

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/changePncNumberController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/changePncNumberController.test.ts
@@ -4,6 +4,7 @@ import cheerio from 'cheerio'
 import { appWithAllRoutes, signedCookiesProvider } from '../../../../__testutils/appSetup'
 import Role from '../../../../../authentication/role'
 import config from '../../../../../config'
+import { expectSettingCookie } from '../../../../__testutils/requestTestUtils'
 
 let app: Express
 
@@ -82,17 +83,13 @@ describe('POST /search-for-existing-record/change-pnc-number', () => {
       .post('/prisoners/12345-67890/search-for-existing-record/change-pnc-number')
       .send({ pncNumber: '11/98644M' })
       .expect(res => {
-        expect(res.header['set-cookie'][0]).toContain(
-          encodeURIComponent(
-            JSON.stringify({
-              firstName: 'James',
-              lastName: 'Smyth',
-              dateOfBirth: '1973-01-08',
-              prisonNumber: 'A1234AB',
-              pncNumber: '11/98644M',
-            })
-          )
-        )
+        expectSettingCookie(res, 'search-details').toStrictEqual({
+          firstName: 'James',
+          lastName: 'Smyth',
+          dateOfBirth: '1973-01-08',
+          prisonNumber: 'A1234AB',
+          pncNumber: '11/98644M',
+        })
       })
   })
 
@@ -131,16 +128,12 @@ describe('GET /search-for-existing-record/remove-pnc-number', () => {
     return request(app)
       .get('/prisoners/12345-67890/search-for-existing-record/remove-pnc-number')
       .expect(res => {
-        expect(res.header['set-cookie'][0]).toContain(
-          encodeURIComponent(
-            JSON.stringify({
-              firstName: 'James',
-              lastName: 'Smyth',
-              dateOfBirth: '1973-01-08',
-              prisonNumber: 'A1234AB',
-            })
-          )
-        )
+        expectSettingCookie(res, 'search-details').toStrictEqual({
+          firstName: 'James',
+          lastName: 'Smyth',
+          dateOfBirth: '1973-01-08',
+          prisonNumber: 'A1234AB',
+        })
       })
   })
 

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/changePrisonNumberController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/changePrisonNumberController.test.ts
@@ -4,6 +4,7 @@ import cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider, signedCookiesProvider } from '../../../../__testutils/appSetup'
 import Role from '../../../../../authentication/role'
 import config from '../../../../../config'
+import { expectSettingCookie } from '../../../../__testutils/requestTestUtils'
 
 let app: Express
 
@@ -81,17 +82,13 @@ describe('POST /search-for-existing-record/change-prison-number', () => {
       .post('/prisoners/12345-67890/search-for-existing-record/change-prison-number')
       .send({ prisonNumber: 'A1234CC' })
       .expect(res => {
-        expect(res.header['set-cookie'][0]).toContain(
-          encodeURIComponent(
-            JSON.stringify({
-              firstName: 'James',
-              lastName: 'Smyth',
-              dateOfBirth: '1973-01-08',
-              prisonNumber: 'A1234CC',
-              pncNumber: '99/98644M',
-            })
-          )
-        )
+        expectSettingCookie(res, 'search-details').toStrictEqual({
+          firstName: 'James',
+          lastName: 'Smyth',
+          dateOfBirth: '1973-01-08',
+          prisonNumber: 'A1234CC',
+          pncNumber: '99/98644M',
+        })
       })
   })
 
@@ -146,16 +143,12 @@ describe('GET /search-for-existing-record/remove-prison-number', () => {
     return request(app)
       .get('/prisoners/12345-67890/search-for-existing-record/remove-prison-number')
       .expect(res => {
-        expect(res.header['set-cookie'][0]).toContain(
-          encodeURIComponent(
-            JSON.stringify({
-              firstName: 'James',
-              lastName: 'Smyth',
-              dateOfBirth: '1973-01-08',
-              pncNumber: '99/98644M',
-            })
-          )
-        )
+        expectSettingCookie(res, 'search-details').toStrictEqual({
+          firstName: 'James',
+          lastName: 'Smyth',
+          dateOfBirth: '1973-01-08',
+          pncNumber: '99/98644M',
+        })
       })
   })
 

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.ts
@@ -47,9 +47,6 @@ export default class SearchForExistingRecordController {
       const searchData = State.searchDetails.get(req)
       const potentialMatches = await this.expectedArrivalsService.getMatchingRecords(searchData)
 
-      if (potentialMatches.length > 1) {
-        return res.redirect(`/prisoners/${id}/search-for-existing-record/possible-records-found`)
-      }
       if (potentialMatches.length === 1) {
         const match = potentialMatches[0]
         State.newArrival.set(res, {
@@ -63,7 +60,12 @@ export default class SearchForExistingRecordController {
 
         return res.redirect(`/prisoners/${id}/search-for-existing-record/record-found`)
       }
-      return res.redirect(`/prisoners/${id}/search-for-existing-record/no-record-found`)
+
+      State.newArrival.clear(res)
+
+      return potentialMatches.length > 1
+        ? res.redirect(`/prisoners/${id}/search-for-existing-record/possible-records-found`)
+        : res.redirect(`/prisoners/${id}/search-for-existing-record/no-record-found`)
     }
   }
 }

--- a/server/views/pages/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecord.njk
+++ b/server/views/pages/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecord.njk
@@ -11,8 +11,7 @@
                     valid PNC or prison number.</p>
                 <p>Check their personal details are correct and add a PNC or prison number if you have one. This information will be
                     used to search for an existing prisoner record.</p>
-                <h2 class="govuk-heading-m">Information from the Person Escort Record</h2>
-                <h3 class="govuk-heading-m">Personal details</h3>
+                <h2 class="govuk-heading-m">Personal details</h2>
                 {% set details = [
                     {   key:     { text: "Name" },
                         value:   { text: data.firstName + " " + data.lastName, classes: 'data-qa-name' },


### PR DESCRIPTION
Fixes an issue where if you:
* Search for a record and produce a match
* Select the match and then go through to check your answers you’ll see the details of the match
* If you navigate back to the search page and alter the query so you produce no match
* Confirm this and progress to the check your answer page you will see the old match

