### PR TITLE
DCS-1504 fix display of sex when single match

### DIFF
--- a/integration_tests/integration/bookedtoday/arrivals/isSingleMatch.spec.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/isSingleMatch.spec.ts
@@ -5,7 +5,6 @@ import CheckAnswersPage from '../../../pages/bookedtoday/arrivals/confirmArrival
 import ConfirmAddedToRollPage from '../../../pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll'
 import Role from '../../../../server/authentication/role'
 import expectedArrivals from '../../../mockApis/responses/expectedArrivals'
-import SexPage from '../../../pages/bookedtoday/arrivals/confirmArrival/sexPage'
 import ChoosePrisonerPage from '../../../pages/bookedtoday/choosePrisoner'
 import MovementReasonsPage from '../../../pages/bookedtoday/arrivals/confirmArrival/movementReasons'
 import SearchForExistingPage from '../../../pages/bookedtoday/arrivals/searchforexisting/search/searchForExisting'
@@ -50,10 +49,6 @@ context('Is Single Match', () => {
     singleMatchingRecordFoundPage.existingPncNumber().should('contain.text', '01/4567A')
     singleMatchingRecordFoundPage.continue().click()
 
-    const sexPage = Page.verifyOnPage(SexPage)
-    sexPage.sexRadioButtons('F').click()
-    sexPage.continue().click()
-
     const imprisonmentStatusPage = Page.verifyOnPage(ImprisonmentStatusPage)
     imprisonmentStatusPage.continue().click()
     imprisonmentStatusPage.hasError('Select a reason for imprisonment')
@@ -72,7 +67,7 @@ context('Is Single Match', () => {
     checkAnswersPage.dob().should('contain.text', '1 February 1970')
     checkAnswersPage.prisonNumber().should('contain.text', 'A1234BC')
     checkAnswersPage.pncNumber().should('contain.text', '01/4567A')
-    checkAnswersPage.sex().should('contain.text', 'Female')
+    checkAnswersPage.sex().should('contain.text', 'Male')
     checkAnswersPage.reason().should('contain.text', 'Determinate sentence - Extended sentence for public protection')
     cy.task('stubCreateOffenderRecordAndBooking', expectedArrival.id)
     checkAnswersPage.addToRoll().click()
@@ -93,7 +88,7 @@ context('Is Single Match', () => {
       expect(request).to.deep.equal({
         dateOfBirth: '1970-02-01',
         firstName: 'Sam',
-        gender: 'F',
+        gender: 'M',
         imprisonmentStatus: 'SENT',
         lastName: 'Smith',
         movementReasonCode: '26',

--- a/integration_tests/mockApis/responses/expectedArrivals.ts
+++ b/integration_tests/mockApis/responses/expectedArrivals.ts
@@ -28,6 +28,7 @@ export default {
     dateOfBirth: '1970-02-01',
     prisonNumber: 'A1234BC',
     pncNumber: '01/4567A',
+    sex: 'MALE',
   },
   other: {
     firstName: 'Steve',

--- a/server/routes/bookedtoday/arrivals/singleMatchingRecordFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/singleMatchingRecordFoundController.test.ts
@@ -35,9 +35,10 @@ beforeEach(() => {
         dateOfBirth: '1973-01-08',
         prisonNumber: 'A1234AB',
         pncNumber: '01/98644M',
+        sex: GenderKeys.FEMALE,
       },
     ],
-  } as unknown as Arrival)
+  } as Arrival)
 })
 
 afterEach(() => {
@@ -67,7 +68,7 @@ describe('GET /view', () => {
           firstName: 'Jim',
           lastName: 'Smith',
           dateOfBirth: '1973-01-08',
-          sex: 'MALE',
+          sex: 'FEMALE',
           prisonNumber: 'A1234AB',
           pncNumber: '01/98644M',
         })

--- a/server/routes/bookedtoday/arrivals/singleMatchingRecordFoundController.ts
+++ b/server/routes/bookedtoday/arrivals/singleMatchingRecordFoundController.ts
@@ -16,8 +16,7 @@ export default class SingleMatchingRecordFoundController {
         firstName: convertToTitleCase(match.firstName),
         lastName: convertToTitleCase(match.lastName),
         dateOfBirth: match.dateOfBirth,
-        // TODO: add sex to potential match object on cookie
-        sex: data.gender,
+        sex: match.sex,
         prisonNumber: match.prisonNumber,
         pncNumber: match.pncNumber,
       })


### PR DESCRIPTION
This previously read the value from the arrival rather than the match

This would only affect the display of the sex in the case it differed or wasn't provided by BASM