### PR TITLE
DCS-1467 display input validation errors

### DIFF
--- a/server/routes/bookedtoday/unexpectedArrivals/index.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/index.ts
@@ -7,6 +7,11 @@ import authorisationForUrlMiddleware from '../../../middleware/authorisationForU
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { Services } from '../../../services'
 import Role from '../../../authentication/role'
+import validationMiddleware from '../../../middleware/validationMiddleware'
+import SearchForExistingRecordsValidation from './validation/searchForExistingRecordsValidation'
+import DateOfBirthValidation from './validation/dateOfBirthValidation'
+import PrisonNumberValidation from './validation/prisonNumberValidation'
+import PncNumberValidation from './validation/pncNumberValidation'
 
 export default function routes(services: Services): Router {
   const router = express.Router()
@@ -28,7 +33,17 @@ export default function routes(services: Services): Router {
   const searchForExistingRecordController = new SearchForExistingRecordController(services.expectedArrivalsService)
   get('', [searchForExistingRecordController.view()], [Role.PRISON_RECEPTION])
 
-  post('', [searchForExistingRecordController.submit()], [Role.PRISON_RECEPTION])
+  post(
+    '',
+    [
+      validationMiddleware(SearchForExistingRecordsValidation),
+      validationMiddleware(DateOfBirthValidation),
+      validationMiddleware(PrisonNumberValidation),
+      validationMiddleware(PncNumberValidation),
+      searchForExistingRecordController.submit(),
+    ],
+    [Role.PRISON_RECEPTION]
+  )
 
   const noExistingRecordsFoundController = new NoExistingRecordsFoundController()
   get('/no-record-found', [noExistingRecordsFoundController.view()], [Role.PRISON_RECEPTION])

--- a/server/routes/bookedtoday/unexpectedArrivals/searchForExistingRecordsController.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/searchForExistingRecordsController.test.ts
@@ -97,6 +97,20 @@ describe('Unexpected arrivals - search for existing records', () => {
         .expect('Location', '/autherror')
     })
 
+    it('should call flash twice if errors and redirect', () => {
+      return request(app)
+        .post('/manually-confirm-arrival/search-for-existing-record')
+        .send({ firstName: 'james' })
+        .expect(302)
+        .expect('Location', '/manually-confirm-arrival/search-for-existing-record')
+        .expect(() => {
+          expect(flashProvider.mock.calls).toEqual([
+            ['errors', [{ href: '#last-name', text: 'Enter a last name' }]],
+            ['input', { firstName: 'james' }],
+          ])
+        })
+    })
+
     it('should use correct details to get matched records', () => {
       return request(app)
         .post('/manually-confirm-arrival/search-for-existing-record')

--- a/server/routes/bookedtoday/unexpectedArrivals/searchForExistingRecordsController.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/searchForExistingRecordsController.ts
@@ -2,14 +2,26 @@ import type { RequestHandler, Response, Request } from 'express'
 import type { ExpectedArrivalsService } from '../../../services'
 import { State } from '../arrivals/state'
 
+type FlashErrors = [{ text: string; href: string }]
+
 export default class SearchForExistingRecordsController {
   public constructor(private readonly expectedArrivalsService: ExpectedArrivalsService) {}
 
   public view(): RequestHandler {
     return async (req, res) => {
+      let expandDetails = false
+      const errors = req.flash('errors') as FlashErrors
+      const prisonNumberOrPncErrors = errors.filter(
+        error => error.href === '#prison-number' || error.href === '#pnc-number'
+      )
+      if (prisonNumberOrPncErrors.length) {
+        expandDetails = true
+      }
+
       res.render('pages/unexpectedArrivals/searchForExistingRecord.njk', {
-        errors: req.flash('errors'),
+        errors,
         data: req.flash('input')[0],
+        expandDetails,
       })
     }
   }

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/dateOfBirthValidation.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/dateOfBirthValidation.test.ts
@@ -1,0 +1,71 @@
+import DateOfBirthValidator from './dateOfBirthValidation'
+
+describe('DateOfBirthValidator', () => {
+  test.each([
+    [
+      { month: '1', year: '2020' },
+      [
+        {
+          href: '#date-of-birth-day',
+          text: 'Date of birth must include a day',
+        },
+      ],
+    ],
+
+    [
+      { day: '1', month: '2' },
+      [
+        {
+          href: '#date-of-birth-year',
+          text: 'Date of birth must include a year',
+        },
+      ],
+    ],
+
+    [
+      { day: '1', year: '2020' },
+      [
+        {
+          href: '#date-of-birth-month',
+          text: 'Date of birth must include a month',
+        },
+      ],
+    ],
+
+    [
+      { day: '1' },
+      [
+        {
+          href: '#date-of-birth-month',
+          text: 'Date of birth must include a month and year',
+        },
+      ],
+    ],
+
+    [
+      { month: '1' },
+      [
+        {
+          href: '#date-of-birth-day',
+          text: 'Date of birth must include a day and year',
+        },
+      ],
+    ],
+
+    [
+      { year: '2020' },
+      [
+        {
+          href: '#date-of-birth-day',
+          text: 'Date of birth must include a day and month',
+        },
+      ],
+    ],
+
+    [{ day: '1', month: '2', year: '2020' }, []],
+
+    [{ day: '01', month: '02', year: '2020' }, []],
+  ])('invalid cases : (%s, %s)', (fields, expectedErrors) => {
+    expect(DateOfBirthValidator(fields)).toEqual(expectedErrors)
+  })
+})

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/dateOfBirthValidation.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/dateOfBirthValidation.ts
@@ -1,0 +1,33 @@
+import moment from 'moment'
+import { Validator } from '../../../../middleware/validationMiddleware'
+import { zip } from '../../../../utils/utils'
+
+type ValidationError = { text?: string; href: string }
+
+const fields = ['day', 'month', 'year']
+
+export const isValidDate = (d: unknown, m: unknown, y: unknown) => {
+  const fullDate = `${y.toString().padStart(4, '0')}-${m.toString().padStart(2, '0')}-${d.toString().padStart(2, '0')}`
+  return moment(fullDate, 'YYYY-MM-DD', true).isValid()
+}
+
+const DateOfBirthValidator: Validator = ({ day: d, month: m, year: y }: Record<string, string>) => {
+  const day = parseInt(d, 10)
+  const month = parseInt(m, 10)
+  const year = parseInt(y, 10)
+  let errors = [] as ValidationError[]
+
+  if (day || month || year) {
+    const missingFieldNames = zip(fields, [day, month, year])
+      .map(([field, value]) => !value && field)
+      .filter(Boolean)
+
+    const message = missingFieldNames.join(' and ')
+    errors = !missingFieldNames.length
+      ? []
+      : [{ text: `Date of birth must include a ${message}`, href: `#date-of-birth-${missingFieldNames[0]}` }]
+  }
+
+  return errors
+}
+export default DateOfBirthValidator

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/pncNumberValidation.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/pncNumberValidation.test.ts
@@ -1,0 +1,31 @@
+import PncNumberValidation from './pncNumberValidation'
+
+describe('PncNumberValidation', () => {
+  it('PNC number optional', () => expect(PncNumberValidation({})).toEqual([]))
+
+  it('valid short-form PNC number', () => expect(PncNumberValidation({ pncNumber: '01/23456A' })).toEqual([]))
+
+  it('valid long-form PNC number', () => expect(PncNumberValidation({ pncNumber: '2001/23456A' })).toEqual([]))
+
+  it('valid PNC number is case insensitive', () => expect(PncNumberValidation({ pncNumber: '01/23456a' })).toEqual([]))
+
+  test.each([
+    ['10000/12345'],
+    ['01/123456A'],
+    ['a'],
+    ['1233AA'],
+    ['A'],
+    ['1'],
+    ['A1234AA '],
+    [' A1234AA'],
+    ['A.234AA'],
+    ['    '],
+  ])('invalid PNC numbers : (%s)', pncNumber => {
+    expect(PncNumberValidation({ pncNumber })).toEqual([
+      {
+        href: '#pnc-number',
+        text: 'Enter a PNC number in the format 01/23456A or 2001/23456A',
+      },
+    ])
+  })
+})

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/pncNumberValidation.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/pncNumberValidation.ts
@@ -1,0 +1,11 @@
+import { Validator } from '../../../../middleware/validationMiddleware'
+
+const PNC_NUMBER_REGEX = /^([0-9]{2}|[0-9]{4})\/[0-9]{5}[a-zA-Z]/
+
+const PncNumberValidator: Validator = ({ pncNumber }: Record<string, string>) => {
+  return pncNumber && !PNC_NUMBER_REGEX.test(pncNumber)
+    ? [{ text: 'Enter a PNC number in the format 01/23456A or 2001/23456A', href: '#pnc-number' }]
+    : []
+}
+
+export default PncNumberValidator

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/prisonNumberValidation.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/prisonNumberValidation.test.ts
@@ -1,0 +1,22 @@
+import PrisonNumberValidation from './prisonNumberValidation'
+
+describe('PrisonNumberValidation', () => {
+  it('Prison number optional', () => expect(PrisonNumberValidation({})).toEqual([]))
+
+  it('valid prison number', () => expect(PrisonNumberValidation({ prisonNumber: 'A1234AA' })).toEqual([]))
+
+  it('valid prison number is case insensitive', () =>
+    expect(PrisonNumberValidation({ prisonNumber: 'A1234Aa' })).toEqual([]))
+
+  test.each([['    '], ['a'], ['1233AA'], ['A'], ['1'], ['A1234AA '], [' A1234AA'], ['A.234AA']])(
+    'invalid prison numbers : (%s)',
+    prisonNumber => {
+      expect(PrisonNumberValidation({ prisonNumber })).toEqual([
+        {
+          href: '#prison-number',
+          text: 'Enter a prison number using 7 characters in the format A1234AA',
+        },
+      ])
+    }
+  )
+})

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/prisonNumberValidation.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/prisonNumberValidation.ts
@@ -1,0 +1,11 @@
+import { Validator } from '../../../../middleware/validationMiddleware'
+
+const PRISON_NUMBER_REGEX = /^[A-Za-z]\d{4}[A-Za-z]{2}$/
+
+const PrisonNumberValidator: Validator = ({ prisonNumber }: Record<string, string>) => {
+  return prisonNumber && !PRISON_NUMBER_REGEX.test(prisonNumber)
+    ? [{ text: 'Enter a prison number using 7 characters in the format A1234AA', href: '#prison-number' }]
+    : []
+}
+
+export default PrisonNumberValidator

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.test.ts
@@ -1,0 +1,23 @@
+import SearchForExistingRecordsValidation from './searchForExistingRecordsValidation'
+
+describe('MatchedRecordSelectionValidation', () => {
+  it('Should return error if nothing is entered', () =>
+    expect(SearchForExistingRecordsValidation({})).toEqual([
+      {
+        text: "You must search using either the prisoner's last name, prison number or PNC Number",
+        href: '#last-name',
+      },
+    ]))
+  it('Should return error if only date of birth is entered', () =>
+    expect(SearchForExistingRecordsValidation({ day: '02', month: '01', year: '2000' })).toEqual([
+      {
+        href: '#last-name',
+        text: "You must search using either the prisoner's last name, prison number or PNC Number",
+      },
+    ]))
+
+  it('Should return error if only first name entered', () =>
+    expect(SearchForExistingRecordsValidation({ firstName: 'James' })).toEqual([
+      { href: '#last-name', text: 'Enter a last name' },
+    ]))
+})

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.ts
@@ -1,0 +1,38 @@
+import { ValidationError, Validator } from '../../../../middleware/validationMiddleware'
+import { isValidDate } from './dateOfBirthValidation'
+
+const SearchForExistingRecordsValidator: Validator = ({
+  firstName,
+  lastName,
+  day,
+  month,
+  year,
+  prisonNumber,
+  pncNumber,
+}: Record<string, string>): ValidationError[] => {
+  if (!lastName && !prisonNumber && !pncNumber && firstName) {
+    return [{ text: 'Enter a last name', href: '#last-name' }]
+  }
+
+  if (!lastName && !prisonNumber && !pncNumber) {
+    return [
+      {
+        text: "You must search using either the prisoner's last name, prison number or PNC Number",
+        href: '#last-name',
+      },
+    ]
+  }
+
+  if (!lastName && !prisonNumber && !pncNumber && day && month && year && isValidDate(day, month, year)) {
+    return [
+      {
+        text: "You must search using either the prisoner's last name, prison number or PNC Number",
+        href: '#last-name',
+      },
+    ]
+  }
+
+  return []
+}
+
+export default SearchForExistingRecordsValidator

--- a/server/views/pages/unexpectedArrivals/searchForExistingRecord.njk
+++ b/server/views/pages/unexpectedArrivals/searchForExistingRecord.njk
@@ -72,35 +72,36 @@
                         }) }}
                         {% endcall %}
 
-                        <details class="govuk-details" data-module="govuk-details" data-qa="other-search-details">
-                            <summary class="govuk-details__summary">
-                                <span class="govuk-details__summary-text">Search using prison number or PNC number</span>
-                            </summary>
+                        {% set otherSearchDetails %}
+                            <p class="govuk-hint">Your search must include either a name, prison number or PNC number</p>
+                            
+                            {{ govukInput({
+                                label: { text: 'Prison number' },
+                                hint: {text: "Enter in the format 'A1234AA'."},
+                                id: "prison-number",
+                                name: "prisonNumber",
+                                classes: 'govuk-input--width-10',
+                                value: data.prisonNumber,
+                                errorMessage: errors | findError('prison-number')
+                            }) }}
 
-                            <div class="govuk-details__text">
-                                <p class="govuk-hint">Your search must include either a name, prison number or PNC number.</p>
+                            {{ govukInput({
+                                label: { text: 'PNC number' },
+                                hint: {text: "Enter in the format '01/23456A'."},
+                                id: "pnc-number",
+                                name: "pncNumber",
+                                classes: 'govuk-input--width-10',
+                                value: data.pncNumber,
+                                errorMessage: errors | findError('pnc-number')
+                            }) }}
+                        {% endset %}
 
-                                {{ govukInput({
-                                    label: { text: 'Prison number' },
-                                    hint: {text: "Enter in the format 'A1234AA'."},
-                                    id: "prison-number",
-                                    name: "prisonNumber",
-                                    classes: 'govuk-input--width-10',
-                                    value: data.prisonNumber,
-                                    errorMessage: errors | findError("prison-number")
-                                }) }}
-
-                                {{ govukInput({
-                                    label: { text: 'PNC number' },
-                                    hint: {text: "Enter in the format '01/123456A'."},
-                                    id: "pnc-number",
-                                    name: "pncNumber",
-                                    classes: 'govuk-input--width-10',
-                                    value: data.pncNumber,
-                                    errorMessage: errors | findError("pnc-number")
-                                }) }}
-                            </div>
-                        </details>
+                        {{ govukDetails({
+                        summaryText: "Search using prison number or PNC number",
+                        html: otherSearchDetails,
+                        open: expandDetails,
+                        attributes: { "data-qa": "other-search-details" }
+                        }) }}
 
                     {{ govukButton({
                             classes: "govuk-button govuk-!-margin-bottom-3",

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -9,6 +9,8 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
 
 
 {% block head %}


### PR DESCRIPTION
validate user inputs on page /manually-confirm-arrival/search-for-existing-record.

for reference, the validation rules are

- Nothing entered: You must search using either the prisoner's last name, prison number or PNC Number (link to last name field)
- DOB only entered: You must search using either the prisoner's last name, prison number or PNC Number (link to last name field)
- If one or more DOB fields are missing: Date of birth must include a [whatever is missing] and [whatever else is missing]
- First name only entered: Enter a last name (link to last name field)
- Incorrectly formatted prison number: Enter a prison number using 7 characters in the format A1234AA (link to prison number)
- Incorrectly formatted PNC number: Enter a PNC number in the format 01/23456A or 2001/23456A (link to PNC number)
