### PR TITLE
DCS-1467 integration tests 

### DIFF
--- a/integration_tests/integration/bookedtoday/unexpectedArrivals/searchForExistingRecord.spec.ts
+++ b/integration_tests/integration/bookedtoday/unexpectedArrivals/searchForExistingRecord.spec.ts
@@ -1,0 +1,77 @@
+import Page from '../../../pages/page'
+import Role from '../../../../server/authentication/role'
+import SearchForExistingPage from '../../../pages/bookedtoday/unexpectedArrivals/searchForExistingRecord'
+import NoRecordFoundPage from '../../../pages/bookedtoday/unexpectedArrivals/noRecordFound'
+import RecordFoundPage from '../../../pages/bookedtoday/unexpectedArrivals/recordFound'
+import PossibleRecordsFoundPage from '../../../pages/bookedtoday/unexpectedArrivals/possibleRecordsFound'
+
+context('Unexpected arrivals - Search for existing record spec', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubPrison', 'MDI')
+    cy.task('stubAuthUser')
+    cy.task('stubUserCaseLoads')
+    cy.signIn()
+    SearchForExistingPage.goTo()
+  })
+
+  it('Redirects to no match page', () => {
+    cy.task('stubUnexpectedArrivalsMatchedRecords', [])
+    const searchPage = Page.verifyOnPage(SearchForExistingPage)
+    searchPage.otherSearchDetails().click()
+    searchPage.firstName().type('James')
+    searchPage.lastName().type('Smith')
+    searchPage.day().type('01')
+    searchPage.month().type('08')
+    searchPage.year().type('2000')
+    searchPage.search().click()
+    Page.verifyOnPage(NoRecordFoundPage)
+  })
+  it('Redirects to single match page', () => {
+    cy.task('stubUnexpectedArrivalsMatchedRecords', [
+      {
+        firstName: 'Bob',
+        lastName: 'Smith',
+        dateOfBirth: '1972-11-21',
+        prisonNumber: 'G0014GM',
+        pncNumber: '01/1111A',
+        croNumber: '01/0000A',
+        sex: 'MALE',
+      },
+    ])
+    const searchPage = Page.verifyOnPage(SearchForExistingPage)
+    searchPage.otherSearchDetails().click()
+    searchPage.prisonNumber().type('G0014GM')
+    searchPage.search().click()
+    Page.verifyOnPage(RecordFoundPage)
+  })
+
+  it('Redirects to multiple match page', () => {
+    cy.task('stubUnexpectedArrivalsMatchedRecords', [
+      {
+        firstName: 'Bob',
+        lastName: 'Smith',
+        dateOfBirth: '1972-11-21',
+        prisonNumber: 'G0014GM',
+        pncNumber: '01/1111A',
+        croNumber: '01/0000A',
+        sex: 'MALE',
+      },
+      {
+        firstName: 'Robert',
+        lastName: 'Smyth',
+        dateOfBirth: '1982-11-21',
+        prisonNumber: 'G0014GM',
+        pncNumber: '01/1111A',
+        croNumber: '01/0000A',
+        sex: 'MALE',
+      },
+    ])
+    const searchPage = Page.verifyOnPage(SearchForExistingPage)
+    searchPage.otherSearchDetails().click()
+    searchPage.pncNumber().type('01/23456M')
+    searchPage.search().click()
+    Page.verifyOnPage(PossibleRecordsFoundPage)
+  })
+})

--- a/integration_tests/mockApis/welcome.ts
+++ b/integration_tests/mockApis/welcome.ts
@@ -79,6 +79,20 @@ export default {
     })
   },
 
+  stubUnexpectedArrivalsMatchedRecords: (matches: Record<string, string>[]): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `/welcome/match-prisoners`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: matches,
+      },
+    })
+  },
+
   stubTransfer: ({
     caseLoadId,
     prisonNumber,

--- a/integration_tests/pages/bookedtoday/unexpectedArrivals/noRecordFound.ts
+++ b/integration_tests/pages/bookedtoday/unexpectedArrivals/noRecordFound.ts
@@ -1,0 +1,7 @@
+import Page from '../../page'
+
+export default class NoRecordFoundPage extends Page {
+  constructor() {
+    super('This person does not have an existing prisoner record')
+  }
+}

--- a/integration_tests/pages/bookedtoday/unexpectedArrivals/possibleRecordsFound.ts
+++ b/integration_tests/pages/bookedtoday/unexpectedArrivals/possibleRecordsFound.ts
@@ -1,0 +1,7 @@
+import Page from '../../page'
+
+export default class PossibleRecordsFoundPage extends Page {
+  constructor() {
+    super('Possible existing records have been found')
+  }
+}

--- a/integration_tests/pages/bookedtoday/unexpectedArrivals/recordFound.ts
+++ b/integration_tests/pages/bookedtoday/unexpectedArrivals/recordFound.ts
@@ -1,0 +1,7 @@
+import Page from '../../page'
+
+export default class RecordFoundPage extends Page {
+  constructor() {
+    super('This person has an existing prisoner record')
+  }
+}

--- a/integration_tests/pages/bookedtoday/unexpectedArrivals/searchForExistingRecord.ts
+++ b/integration_tests/pages/bookedtoday/unexpectedArrivals/searchForExistingRecord.ts
@@ -1,0 +1,30 @@
+import Page, { PageElement } from '../../page'
+
+export default class SearchForExistingRecordPage extends Page {
+  constructor() {
+    super('Search for an existing prisoner record')
+  }
+
+  static goTo(): SearchForExistingRecordPage {
+    cy.visit('/manually-confirm-arrival/search-for-existing-record')
+    return Page.verifyOnPage(SearchForExistingRecordPage)
+  }
+
+  firstName = (): PageElement => cy.get('[data-qa=first-name]')
+
+  lastName = (): PageElement => cy.get('[data-qa=last-name]')
+
+  day = (): PageElement => cy.get('[data-qa=day]')
+
+  month = (): PageElement => cy.get('[data-qa=month]')
+
+  year = (): PageElement => cy.get('[data-qa=year]')
+
+  otherSearchDetails = (): PageElement => cy.get('[data-qa=other-search-details]')
+
+  prisonNumber = (): PageElement => cy.get('[data-qa=prison-number]')
+
+  pncNumber = (): PageElement => cy.get('[data-qa=pnc-number]')
+
+  search = (): PageElement => cy.get('[data-qa=search]')
+}

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -34,6 +34,7 @@ export default (on: (string, Record) => void): void => {
     stubCreateOffenderRecordAndBookingReturnsError: welcome.stubCreateOffenderRecordAndBookingReturnsError,
     stubImprisonmentStatus: welcome.stubImprisonmentStatus,
     stubMatchedRecords: welcome.stubMatchedRecords,
+    stubUnexpectedArrivalsMatchedRecords: welcome.stubUnexpectedArrivalsMatchedRecords,
     stubPrisonerDetails: welcome.stubPrisonerDetails,
     getCourtReturnConfirmationRequest: welcome.getCourtReturnConfirmationRequest,
     getConfirmationRequest: welcome.getConfirmationRequest,

--- a/server/views/pages/unexpectedArrivals/searchForExistingRecord.njk
+++ b/server/views/pages/unexpectedArrivals/searchForExistingRecord.njk
@@ -29,7 +29,8 @@
                                 name: "firstName",
                                 classes: 'govuk-input--width-10',
                                 value: data.firstName,
-                                errorMessage: errors | findError("first-name")
+                                errorMessage: errors | findError("first-name"),
+                                attributes: {"data-qa": "first-name"}
                             }) }}
 
                             {{ govukInput({
@@ -38,7 +39,8 @@
                                 name: "lastName",
                                 classes: 'govuk-input--width-10',
                                 value: data.lastName,
-                                errorMessage: errors | findError("last-name")
+                                errorMessage: errors | findError("last-name"),
+                                attributes: {"data-qa": "last-name"}
                             }) }}
 
                             {{ govukDateInput({
@@ -56,17 +58,21 @@
                                     {
                                     classes: "govuk-input--width-2",
                                     name: "day",
-                                    value: data.day | default(data.dateOfBirth | formatDate('DD'))
+                                    value: data.day | default(data.dateOfBirth | formatDate('DD')),
+                                    attributes: {"data-qa": "day"}
+
                                     },
                                     {
                                     classes: "govuk-input--width-2",
                                     name: "month",
-                                    value: data.month | default(data.dateOfBirth | formatDate('MM'))
+                                    value: data.month | default(data.dateOfBirth | formatDate('MM')),
+                                    attributes: {"data-qa": "month"}
                                     },
                                     {
                                     classes: "govuk-input--width-4",
                                     name: "year",
-                                    value: data.year | default(data.dateOfBirth | formatDate('YYYY'))
+                                    value: data.year | default(data.dateOfBirth | formatDate('YYYY')),
+                                    attributes: {"data-qa": "year"}
                                     }
                                 ]
                         }) }}
@@ -82,7 +88,8 @@
                                 name: "prisonNumber",
                                 classes: 'govuk-input--width-10',
                                 value: data.prisonNumber,
-                                errorMessage: errors | findError('prison-number')
+                                errorMessage: errors | findError('prison-number'),
+                                attributes: {"data-qa": "prison-number"}
                             }) }}
 
                             {{ govukInput({
@@ -92,7 +99,8 @@
                                 name: "pncNumber",
                                 classes: 'govuk-input--width-10',
                                 value: data.pncNumber,
-                                errorMessage: errors | findError('pnc-number')
+                                errorMessage: errors | findError('pnc-number'),
+                                attributes: {"data-qa": "pnc-number"}
                             }) }}
                         {% endset %}
 
@@ -106,7 +114,7 @@
                     {{ govukButton({
                             classes: "govuk-button govuk-!-margin-bottom-3",
                             text: "Search",
-                            attributes: {'data-qa': 'save'},
+                            attributes: {'data-qa': 'search'},
                             type: 'submit'
                     }) }}         
                  </form>                              


### PR DESCRIPTION
to test the  /manually-confirm-arrival/search-for-existing-record page

note 
work is currently being done to set up a new endpoint to retrieve matches from the backend. This means the 'urlPattern' in stubUnexpectedArrivalsMatchedRecords will change as well as in the searchForExistingRecordsController.
