### PR TITLE
DCS-1466 add link on prisoner search page

### DIFF
--- a/integration_tests/integration/bookedtoday/choosePrisoner.spec.ts
+++ b/integration_tests/integration/bookedtoday/choosePrisoner.spec.ts
@@ -32,7 +32,7 @@ context('Choose Prisoner', () => {
     cy.task('stubMissingPrisonerImage')
   })
 
-  it('Should display available prisoner info', () => {
+  it("Should display available prisoner info and the 'manually confirm' link", () => {
     cy.signIn()
     const choosePrisonerPage = ChoosePrisonerPage.goTo()
 
@@ -49,6 +49,7 @@ context('Choose Prisoner', () => {
     choosePrisonerPage.pncNumber(1, 'CUSTODY_SUITE').should('not.exist')
 
     choosePrisonerPage.expectedArrivalsFromAnotherEstablishment(1).should('contain.text', 'Offender, Karl')
+    choosePrisonerPage.manuallyConfirmArrival().should('exist')
   })
 
   it('Should handle no expected arrivals', () => {
@@ -216,5 +217,6 @@ context('Choose Prisoner', () => {
     choosePrisonerPage.arrivalFrom('COURT')(1).confirm().should('not.exist')
     choosePrisonerPage.arrivalFrom('COURT')(2).confirm().should('not.exist')
     choosePrisonerPage.arrivalFrom('COURT')(3).confirm().should('not.exist')
+    choosePrisonerPage.manuallyConfirmArrival().should('not.exist')
   })
 })

--- a/integration_tests/pages/bookedtoday/choosePrisoner.ts
+++ b/integration_tests/pages/bookedtoday/choosePrisoner.ts
@@ -40,4 +40,6 @@ export default class ChoosePrisonerPage extends Page {
     (row: number): Record<string, () => PageElement> => ({
       confirm: () => cy.get(`[data-qa=${arrivalFromType}-title-${row}]`).find(`[data-qa=confirm-arrival]`),
     })
+
+  manuallyConfirmArrival = (): PageElement => cy.get('[data-qa=manually-confirm-arrival]')
 }

--- a/server/views/pages/bookedtoday/choosePrisoner.njk
+++ b/server/views/pages/bookedtoday/choosePrisoner.njk
@@ -19,12 +19,16 @@
                         <p data-qa="no-arrivals-from-custody-suite">There are currently no prisoners booked to arrive from a custody suite today.</p>
                     {% endfor %}
 
-                 <h2 class="govuk-heading-m govuk-!-margin-top-9">Prisoners arriving from another establishment</h2>
+                <h2 class="govuk-heading-m govuk-!-margin-top-9">Prisoners arriving from another establishment</h2>
                     {% for arrival in expectedArrivals.get("PRISON") %}
                         {{ transferCard(arrival, loop.index, user) }}
                     {% else %}
                         <p data-qa="no-arrivals-from-another-establishment">There are currently no prisoners booked to arrive from another establishment today.</p>
                     {% endfor %}
+
+                {% if user.isReceptionUser %}
+                    <p class="govuk-inset-text" data-qa="manually-confirm-arrival">If the prisoner is not on this list, you can <a href="/manually-confirm-arrival/search-for-existing-record" class="govuk-link govuk-link--no-visited-state">manually confirm their arrival</a>.</p>
+                {% endif %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Link takes user /manually-confirm-arrival/search-for-existing-record
Only visible if user has reception role