### PR TITLE
DCS-1553 Prevent passing of prison number on new record

### DIFF
--- a/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasNoMatchAndPncOnly.spec.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasNoMatchAndPncOnly.spec.ts
@@ -144,7 +144,6 @@ context('No match found', () => {
         imprisonmentStatus: 'RX',
         movementReasonCode: 'R',
         prisonId: 'MDI',
-        prisonNumber: null,
       })
     })
   })

--- a/server/routes/bookedtoday/arrivals/reviewPerDetailsController.test.ts
+++ b/server/routes/bookedtoday/arrivals/reviewPerDetailsController.test.ts
@@ -87,7 +87,6 @@ describe('GET /review-per-details', () => {
           dateOfBirth: '1973-01-08',
           sex: 'MALE',
           pncNumber: '99/98644M',
-          prisonNumber: 'A1234AB',
           expected: 'true',
         })
       })

--- a/server/routes/bookedtoday/arrivals/reviewPerDetailsController.ts
+++ b/server/routes/bookedtoday/arrivals/reviewPerDetailsController.ts
@@ -15,7 +15,6 @@ export default class ReviewPerDetailsController {
       dateOfBirth: arrival.dateOfBirth,
       sex: arrival.gender,
       pncNumber: arrival.pncNumber,
-      prisonNumber: arrival.prisonNumber,
       expected: true,
     }
 


### PR DESCRIPTION
This would only happen if we received an invalid prison number from BASM. We were previously passing it through even though it must have been invalid else we would have received a match