### PR TITLE
DCS-1541 handle display of prisoner search details

### DIFF
--- a/server/views/components/prisoner-search-detail.njk
+++ b/server/views/components/prisoner-search-detail.njk
@@ -1,0 +1,37 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro prisonerSearchDetail(data, dataQa) %}
+
+    {% set firstName = data.firstName %}
+    {% set lastName = data.lastName %}
+    {% set dateOfBirth = data.dateOfBirth %}
+
+    {% if firstName or lastName %}
+        {% set name = firstName | default('') + " " + lastName %}
+    {% endif %}
+
+
+    {% set rows = [
+        {   key:     { text: "Name", classes:"govuk-!-padding-bottom-0" },
+            value:   { text: name | default('Not entered', true), classes: "govuk-!-padding-bottom-0 data-qa-" + dataQa + "-prisoner-name" }
+        },
+        {   key:     { text: "Date of birth", classes:"govuk-!-padding-bottom-0" },
+            value:   { text: dateOfBirth | formatDate('D MMMM YYYY') if dateOfBirth else 'Not entered' , classes: "govuk-!-padding-bottom-0 data-qa-" + dataQa + "-dob" }
+        },
+        {   key:     { text: "Prison number", classes: "govuk-!-padding-bottom-0" },
+            value:   { text:  data.prisonNumber | default('Not entered', true),  classes: "govuk-!-padding-bottom-0 data-qa-"+ dataQa + "-prison-number" }    
+        },
+        {   key:     { text: "PNC number", classes: "govuk-!-padding-bottom-0" },
+            value:   { text:  data.pncNumber | default('Not entered', true), classes: "govuk-!-padding-bottom-0 data-qa-" + dataQa + "-pnc-number" }   
+        }
+    ] 
+    %}
+
+    <div>
+      {{ govukSummaryList({
+      attributes: {'data-qa': dataQa},
+      classes: "govuk-!-margin-bottom-0 govuk-summary-list--no-border",
+      rows: rows
+      }) }}
+  </div>
+{% endmacro %}

--- a/server/views/pages/unexpectedArrivals/multipleExistingRecordsFound.njk
+++ b/server/views/pages/unexpectedArrivals/multipleExistingRecordsFound.njk
@@ -1,5 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 {% from "../../components/prisoner-summary-detail.njk" import prisonerSummaryDetail %}
+{% from "../../components/prisoner-search-detail.njk" import prisonerSearchDetail %}
 
 {% set pageTitle = "Possible existing records have been found" %}
 
@@ -28,7 +29,7 @@
             <div class="govuk-grid-column-one-half column-width-40 govuk-!-padding-left-0 govuk-!-padding-right-9">
                 <h2 class="govuk-heading-m">Personal details</h2>
                 <div class = "prisoner-record-detail govuk-!-margin-bottom-4">
-                    {{ prisonerSummaryDetail(arrival, "arrival-details" ) }}
+                    {{ prisonerSearchDetail(arrival, "arrival-details" ) }}
                 </div>
                 <a class="govuk-body govuk-link govuk-link--no-visited-state" href="/manually-confirm-arrival/search-for-existing-record/" data-qa="ammend-search">
                     Search using different details

--- a/server/views/pages/unexpectedArrivals/noExistingRecordsFound.njk
+++ b/server/views/pages/unexpectedArrivals/noExistingRecordsFound.njk
@@ -1,5 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 {% from "../../components/prisoner-summary-detail.njk" import prisonerSummaryDetail %}
+{% from "../../components/prisoner-search-detail.njk" import prisonerSearchDetail %}
 
 {% set pageTitle = "Confirm arrival" %}
 
@@ -8,14 +9,14 @@
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-xl"> Confirm a prisoner's arrival </span>
             <h1 class="govuk-heading-l govuk-!-margin-bottom-7">This person does not have an existing prisoner record</h1>
-            <p> {{ data.firstName }} {{ data.lastName }} does not have an existing prisoner record. A new record will be created when they are added to the establishment roll. </p>
+            <p> A new record will be created when they are added to the establishment roll. </p>
         </div>
     </div>
     <div class="govuk-grid-row govuk-!-margin-top-4 govuk-!-margin-bottom-8 flex" >
         <div class="govuk-grid-column-one-half">
             <h2 class="govuk-heading-m">Personal details</h2>
             <div class = "prisoner-record-detail prisoner-head">
-                {{ prisonerSummaryDetail(data, "arrival" ) }}
+                {{ prisonerSearchDetail(data, "arrival" ) }}
             </div>
         </div>
     </div> 

--- a/server/views/pages/unexpectedArrivals/singleExistingRecordFound.njk
+++ b/server/views/pages/unexpectedArrivals/singleExistingRecordFound.njk
@@ -1,5 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 {% from "../../components/prisoner-summary-detail.njk" import prisonerSummaryDetail %}
+{% from "../../components/prisoner-search-detail.njk" import prisonerSearchDetail %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -12,7 +13,7 @@
         <div class="column-width-40 govuk-!-padding-right-9">
             <h2 class="govuk-heading-m">Personal details</h2>
             <div class = "prisoner-record-detail prisoner-head">
-                {{ prisonerSummaryDetail(data, "arrival" ) }}
+                {{ prisonerSearchDetail(data, "arrival" ) }}
             </div>
             <p class="govuk-!-margin-top-4">
                 <a class="govuk-link govuk-link--no-visited-state" href="/manually-confirm-arrival/search-for-existing-record"  data-qa="search-again">Search using different details</a>


### PR DESCRIPTION
If either of prisoner name, dob, prison number, pnc are not provided in search the text 'Not entered' will be displayed.
If the first name is not provided but last name is, then first name will not be displayed. 
Previously the above missing criteria would result in the ui displaying 'undefined' 