### PR TITLE
DCS-1574 validation for missing last name

### DIFF
--- a/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.test.ts
@@ -17,6 +17,16 @@ describe('MatchedRecordSelectionValidation', () => {
       },
     ]))
 
+  it('Should return error if only DOB and prison number', () =>
+    expect(
+      SearchForExistingRecordsValidation({ day: '02', month: '01', year: '2000', prisonNumber: 'A1234BC' })
+    ).toEqual([
+      {
+        href: '#last-name',
+        text: "You must search using either the prisoner's last name and date of birth, prison number or PNC Number",
+      },
+    ]))
+
   it('Should return error if only first name entered', () =>
     expect(SearchForExistingRecordsValidation({ firstName: 'James' })).toEqual([
       { href: '#last-name', text: 'Enter a last name and a date of birth' },

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.test.ts
@@ -8,6 +8,7 @@ describe('MatchedRecordSelectionValidation', () => {
         href: '#last-name',
       },
     ]))
+
   it('Should return error if only date of birth is entered', () =>
     expect(SearchForExistingRecordsValidation({ day: '02', month: '01', year: '2000' })).toEqual([
       {
@@ -19,5 +20,20 @@ describe('MatchedRecordSelectionValidation', () => {
   it('Should return error if only first name entered', () =>
     expect(SearchForExistingRecordsValidation({ firstName: 'James' })).toEqual([
       { href: '#last-name', text: 'Enter a last name and a date of birth' },
+    ]))
+
+  it('Should return error if only first name and last name entered', () =>
+    expect(SearchForExistingRecordsValidation({ firstName: 'James', lastName: 'Smith' })).toEqual([
+      { href: '#date-of-birth-day', text: 'Enter a date of birth' },
+    ]))
+
+  it('Should return error if only first name and date of birth entered', () =>
+    expect(SearchForExistingRecordsValidation({ firstName: 'James', day: '02', month: '01', year: '2000' })).toEqual([
+      { href: '#last-name', text: 'Enter a last name' },
+    ]))
+
+  it('Should return error if only last name entered', () =>
+    expect(SearchForExistingRecordsValidation({ lastName: 'Smith' })).toEqual([
+      { href: '#date-of-birth-day', text: 'Enter a date of birth' },
     ]))
 })

--- a/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/validation/searchForExistingRecordsValidation.ts
@@ -9,11 +9,15 @@ const SearchForExistingRecordsValidator: Validator = ({
   prisonNumber,
   pncNumber,
 }: Record<string, string>): ValidationError[] => {
-  if (firstName && !lastName && (!day || !month || !year)) {
+  if (firstName && !lastName && !day && !month && !year) {
     return [{ text: 'Enter a last name and a date of birth', href: '#last-name' }]
   }
 
-  if (!lastName && !prisonNumber && !pncNumber) {
+  if (firstName && !lastName) {
+    return [{ text: 'Enter a last name', href: '#last-name' }]
+  }
+
+  if ((!firstName && !lastName && day && month && year) || (!lastName && !prisonNumber && !pncNumber)) {
     return [
       {
         text: "You must search using either the prisoner's last name and date of birth, prison number or PNC Number",


### PR DESCRIPTION
Validation prevents a search when either first name or dob are present but last name is missing.
This also means, the last name will not be displayed as 'undefined' in the search results page