### PR TITLE
DCS-1581 welcomeApi client errors return null or throw error

### DIFF
--- a/server/data/welcomeClient.test.ts
+++ b/server/data/welcomeClient.test.ts
@@ -166,6 +166,24 @@ describe('welcomeClient', () => {
 
       return expect(welcomeClient.confirmCourtReturn(id, 'MDI', 'A1234AA')).resolves.toStrictEqual(arrivalResponse)
     })
+    it('should return null', async () => {
+      fakeWelcomeApi
+        .post(`/court-returns/${id}/confirm`, { prisonId: 'MDI', prisonNumber: 'A1234AA' })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(404)
+
+      const output = await welcomeClient.confirmCourtReturn(id, 'MDI', 'A1234AA')
+      return expect(output).toBe(null)
+    })
+
+    it('should throw server error', async () => {
+      fakeWelcomeApi
+        .post(`/court-returns/${id}/confirm`, { prisonId: 'MDI', prisonNumber: 'A1234AA' })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(500)
+
+      await expect(welcomeClient.confirmCourtReturn(id, 'MDI', 'A1234AA')).rejects.toThrow('Internal Server Error')
+    })
   })
 
   describe('getPrison', () => {

--- a/server/data/welcomeClient.ts
+++ b/server/data/welcomeClient.ts
@@ -39,12 +39,19 @@ export default class WelcomeClient {
     }) as Promise<Arrival>
   }
 
-  async confirmCourtReturn(id: string, prisonId: string, prisonNumber: string): Promise<ArrivalResponse> {
+  async confirmCourtReturn(id: string, prisonId: string, prisonNumber: string): Promise<ArrivalResponse | null> {
     logger.info(`welcomeApi: confirmCourtReturn ${id})`)
-    return this.restClient.post({
-      path: `/court-returns/${id}/confirm`,
-      data: { prisonId, prisonNumber },
-    }) as Promise<ArrivalResponse>
+    try {
+      return (await this.restClient.post({
+        path: `/court-returns/${id}/confirm`,
+        data: { prisonId, prisonNumber },
+      })) as Promise<ArrivalResponse>
+    } catch (error) {
+      if (error.status >= 400 && error.status < 500) {
+        return null
+      }
+      throw error
+    }
   }
 
   async getTransfers(agencyId: string): Promise<Arrival[]> {

--- a/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
@@ -107,5 +107,15 @@ describe('checkCourtReturnController', () => {
         .expect(302)
         .expect('Location', '/prisoners/12345-67890/prisoner-returned-from-court')
     })
+
+    it('should redirect to feature-not-available', () => {
+      expectedArrivalsService.confirmCourtReturn.mockResolvedValue(null)
+
+      return request(app)
+        .post('/prisoners/12345-67890/check-court-return')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect(302)
+        .expect('Location', '/feature-not-available')
+    })
   })
 })

--- a/server/services/expectedArrivalsService.test.ts
+++ b/server/services/expectedArrivalsService.test.ts
@@ -240,6 +240,13 @@ describe('Expected arrivals service', () => {
       expect(WelcomeClientFactory).toBeCalledWith(token)
       expect(welcomeClient.confirmCourtReturn).toBeCalledWith('12345-67890', 'MDI', 'A1234AA')
     })
+
+    it('Should return null', async () => {
+      welcomeClient.confirmCourtReturn.mockResolvedValue(null)
+
+      const result = await service.confirmCourtReturn('user1', '12345-67890', 'MDI', 'A1234AA')
+      expect(result).toBe(null)
+    })
   })
 
   describe('matching records', () => {

--- a/server/services/expectedArrivalsService.ts
+++ b/server/services/expectedArrivalsService.ts
@@ -140,7 +140,7 @@ export default class ExpectedArrivalsService {
     id: string,
     prisonId: string,
     prisonNumber: string
-  ): Promise<ArrivalResponse> {
+  ): Promise<ArrivalResponse | null> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     return this.welcomeClientFactory(token).confirmCourtReturn(id, prisonId, prisonNumber)
   }


### PR DESCRIPTION
a status code between  400 and 500 from welcomeApi determines the redirect to /feature-not-available.
This PR is for court returns journey only. 