### PR TITLE
DCS-1581 handle client errors for transfers

### DIFF
--- a/server/data/welcomeClient.test.ts
+++ b/server/data/welcomeClient.test.ts
@@ -139,11 +139,29 @@ describe('welcomeClient', () => {
     const prisonNumber = 'A1234AB'
     it('should call rest client successfully', async () => {
       fakeWelcomeApi
-        .post(`/transfers/${prisonNumber}/confirm`, {})
+        .post(`/transfers/${prisonNumber}/confirm`)
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, arrivalResponse)
 
       return expect(welcomeClient.confirmTransfer(prisonNumber)).resolves.toStrictEqual(arrivalResponse)
+    })
+    it('should return null', async () => {
+      fakeWelcomeApi
+        .post(`/transfers/${prisonNumber}/confirm`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(404)
+
+      const output = await welcomeClient.confirmTransfer(prisonNumber)
+      return expect(output).toBe(null)
+    })
+
+    it('should throw server error', async () => {
+      fakeWelcomeApi
+        .post(`/transfers/${prisonNumber}/confirm`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(500)
+
+      await expect(welcomeClient.confirmTransfer(prisonNumber)).rejects.toThrow('Internal Server Error')
     })
   })
 

--- a/server/data/welcomeClient.ts
+++ b/server/data/welcomeClient.ts
@@ -68,11 +68,18 @@ export default class WelcomeClient {
     }) as Promise<Transfer>
   }
 
-  async confirmTransfer(prisonNumber: string): Promise<ArrivalResponse> {
+  async confirmTransfer(prisonNumber: string): Promise<ArrivalResponse | null> {
     logger.info(`welcomeApi: confirmTransfer ${prisonNumber})`)
-    return this.restClient.post({
-      path: `/transfers/${prisonNumber}/confirm`,
-    }) as Promise<ArrivalResponse>
+    try {
+      return (await this.restClient.post({
+        path: `/transfers/${prisonNumber}/confirm`,
+      })) as Promise<ArrivalResponse>
+    } catch (error) {
+      if (error.status >= 400 && error.status < 500) {
+        return null
+      }
+      throw error
+    }
   }
 
   async getTemporaryAbsences(agencyId: string): Promise<TemporaryAbsence[]> {

--- a/server/routes/bookedtoday/transfers/checkTransferController.test.ts
+++ b/server/routes/bookedtoday/transfers/checkTransferController.test.ts
@@ -115,4 +115,13 @@ describe('POST addToRoll', () => {
       .expect(302)
       .expect('Location', '/prisoners/A1234AB/confirm-transfer')
   })
+  it('should redirect to feature-not-available', () => {
+    transfersService.confirmTransfer.mockResolvedValue(null)
+
+    return request(app)
+      .post('/prisoners/A1234AB/check-transfer')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .expect(302)
+      .expect('Location', '/feature-not-available')
+  })
 })

--- a/server/routes/bookedtoday/transfers/checkTransferController.ts
+++ b/server/routes/bookedtoday/transfers/checkTransferController.ts
@@ -25,6 +25,10 @@ export default class CheckTransferController {
 
       const arrivalResponse = await this.transfersService.confirmTransfer(username, prisonNumber)
 
+      if (!arrivalResponse) {
+        return res.redirect('/feature-not-available')
+      }
+
       req.flash('prisoner', {
         firstName: data.firstName,
         lastName: data.lastName,
@@ -37,7 +41,7 @@ export default class CheckTransferController {
         `AgencyId: ${activeCaseLoadId}, From: ${data.fromLocation}, Type: 'PRISON',`
       )
 
-      res.redirect(`/prisoners/${prisonNumber}/confirm-transfer`)
+      return res.redirect(`/prisoners/${prisonNumber}/confirm-transfer`)
     }
   }
 }

--- a/server/services/transfersService.test.ts
+++ b/server/services/transfersService.test.ts
@@ -50,5 +50,11 @@ describe('Transfers service', () => {
       expect(WelcomeClientFactory).toBeCalledWith(token)
       expect(welcomeClient.confirmTransfer).toBeCalledWith('G0015GD')
     })
+    it('Should return null', async () => {
+      welcomeClient.confirmTransfer.mockResolvedValue(null)
+
+      const result = await await service.confirmTransfer('user1', 'G0015GD')
+      expect(result).toBe(null)
+    })
   })
 })

--- a/server/services/transfersService.ts
+++ b/server/services/transfersService.ts
@@ -13,7 +13,7 @@ export default class TransfersService {
     return welcomeClient.getTransfer(agencyId, prisonNumber)
   }
 
-  public async confirmTransfer(username: string, prisonNumber: string): Promise<ArrivalResponse> {
+  public async confirmTransfer(username: string, prisonNumber: string): Promise<ArrivalResponse | null> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     return this.welcomeClientFactory(token).confirmTransfer(prisonNumber)
   }


### PR DESCRIPTION
400-500 client errors when calling welcome-api will cause null to be returned to the controller which which will then redirect to /feature-not-available