### PR TITLE
DCS-1081 prometheus alerts for prod to elp_alerts slack channel

### DIFF
--- a/helm_deploy/hmpps-welcome-people-into-prison-ui/Chart.yaml
+++ b/helm_deploy/hmpps-welcome-people-into-prison-ui/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: 1.1.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.1.4
+    version: 0.4.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-welcome-people-into-prison-ui/values.yaml
+++ b/helm_deploy/hmpps-welcome-people-into-prison-ui/values.yaml
@@ -103,3 +103,4 @@ generic-service:
 
 generic-prometheus-alerts:
   targetApplication: hmpps-welcome-people-into-prison-ui
+  alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -22,6 +22,3 @@ generic-service:
     CONFIRM_ENABLED: 'true'
     CONFIRM_NO_IDENTIFIERS_ENABLED: 'true'
     TEMPORARY_ABSENCE_ENABLED: 'true'
-
-generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,7 +20,3 @@ generic-service:
     CONFIRM_ENABLED: 'true'
     CONFIRM_NO_IDENTIFIERS_ENABLED: 'true'
     TEMPORARY_ABSENCE_ENABLED: 'true'
-
-generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
-

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,5 +21,5 @@ generic-service:
     TEMPORARY_ABSENCE_ENABLED: 'false'
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
-
+  targetApplication: hmpps-welcome-people-into-prison-ui
+  alertSeverity: elp_alerts


### PR DESCRIPTION
Dev and Preprod to digital-prison-service-dev.
Prod to elp_alerts.
Latest version of generic-proetheus-alerts is 0.4.1, see https://github.com/ministryofjustice/hmpps-helm-charts/releases?page=1