### PR TITLE
DCS-1651 Extending timeouts to calls for pages displaying lists and disabling retries

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -15,21 +15,25 @@ function get<T>(name: string, fallback: T, options = { requireInProduction: fals
 
 const requiredInProduction = { requireInProduction: true }
 
-export class AgentConfig {
-  maxSockets: 100
-
-  maxFreeSockets: 10
-
-  freeSocketTimeout: 30000
-}
-
 export interface ApiConfig {
   url: string
   timeout: {
     response: number
     deadline: number
   }
-  agent: AgentConfig
+  agent: {
+    maxSockets: number
+    maxFreeSockets: number
+    freeSocketTimeout: number
+  }
+}
+
+export type AgentConfig = Readonly<ApiConfig['agent']>
+
+export const DEFAULT_AGENT_CONFIG: AgentConfig = {
+  maxSockets: 100,
+  maxFreeSockets: 10,
+  freeSocketTimeout: 30000,
 }
 
 export default {
@@ -58,7 +62,7 @@ export default {
         response: Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('HMPPS_AUTH_TIMEOUT_DEADLINE', 10000)),
       },
-      agent: new AgentConfig(),
+      agent: DEFAULT_AGENT_CONFIG,
       apiClientId: get('API_CLIENT_ID', 'clientid', requiredInProduction),
       apiClientSecret: get('API_CLIENT_SECRET', 'clientsecret', requiredInProduction),
       systemClientId: get('SYSTEM_CLIENT_ID', 'clientid', requiredInProduction),
@@ -70,7 +74,7 @@ export default {
         response: Number(get('TOKEN_VERIFICATION_API_TIMEOUT_RESPONSE', 5000)),
         deadline: Number(get('TOKEN_VERIFICATION_API_TIMEOUT_DEADLINE', 5000)),
       },
-      agent: new AgentConfig(),
+      agent: DEFAULT_AGENT_CONFIG,
       enabled: get('TOKEN_VERIFICATION_ENABLED', 'false') === 'true',
     },
     welcome: {
@@ -79,7 +83,7 @@ export default {
         response: Number(get('WELCOME_API_TIMEOUT_RESPONSE', 5000)),
         deadline: Number(get('WELCOME_API_TIMEOUT_DEADLINE', 5000)),
       },
-      agent: new AgentConfig(),
+      agent: DEFAULT_AGENT_CONFIG,
     },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),

--- a/server/data/healthCheck.test.ts
+++ b/server/data/healthCheck.test.ts
@@ -1,9 +1,9 @@
 import nock from 'nock'
 import { serviceCheckFactory } from './healthCheck'
-import { AgentConfig } from '../config'
+import { DEFAULT_AGENT_CONFIG } from '../config'
 
 describe('Service healthcheck', () => {
-  const healthcheck = serviceCheckFactory('externalService', 'http://test-service.com/ping', new AgentConfig(), {
+  const healthcheck = serviceCheckFactory('externalService', 'http://test-service.com/ping', DEFAULT_AGENT_CONFIG, {
     response: 100,
     deadline: 150,
   })

--- a/server/data/welcomeClient.ts
+++ b/server/data/welcomeClient.ts
@@ -31,6 +31,8 @@ export default class WelcomeClient {
     return this.restClient.get({
       path: `/prisons/${agencyId}/arrivals`,
       query: { date: date.format('YYYY-MM-DD') },
+      timeout: 15000,
+      retryCount: 0,
     }) as Promise<Arrival[]>
   }
 
@@ -55,6 +57,8 @@ export default class WelcomeClient {
         toDate: toDate.format('YYYY-MM-DD'),
         query: searchQuery,
       },
+      timeout: 15000,
+      retryCount: 0,
     }) as Promise<PaginatedResponse<RecentArrival>>
   }
 


### PR DESCRIPTION


Disabling retries and extending timeouts so we don’t batter BASM as much when they’re having perf issues. 

Also means patient users are more likely to see results quicker!