### PR TITLE
Centralising test mock creation

### DIFF
--- a/jobs/eventsRetriever.test.ts
+++ b/jobs/eventsRetriever.test.ts
@@ -1,12 +1,10 @@
 import moment from 'moment'
 import { Readable } from 'stream'
 import EventsRetriever from './eventsRetriever'
-import { HmppsAuthClient, WelcomeClient } from '../server/data'
+import { createMockHmppsAuthClient, createMockWelcomeClient } from '../server/data/__testutils/mocks'
 
-jest.mock('../server/data')
-
-const welcomeClient = new WelcomeClient(null) as jest.Mocked<WelcomeClient>
-const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+const welcomeClient = createMockWelcomeClient()
+const hmppsAuthClient = createMockHmppsAuthClient()
 
 let eventsRetriever: EventsRetriever
 

--- a/server/bodyscan/services/bodyScanService.test.ts
+++ b/server/bodyscan/services/bodyScanService.test.ts
@@ -1,24 +1,21 @@
 import { BodyScan } from 'body-scan'
-import { HmppsAuthClient } from '../../data'
+import { createMockHmppsAuthClient } from '../../data/__testutils/mocks'
 import { BodyScanClient } from '../data'
 import BodyScanService from './bodyScanService'
 
-jest.mock('../../data')
 jest.mock('../data')
 
 const token = 'some token'
 
 describe('Body scan service', () => {
-  let bodyScanClient: jest.Mocked<BodyScanClient>
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  const bodyScanClient = new BodyScanClient(null) as jest.Mocked<BodyScanClient>
+  const hmppsAuthClient = createMockHmppsAuthClient()
   let service: BodyScanService
 
   const BodyScanClientFactory = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    bodyScanClient = new BodyScanClient(null) as jest.Mocked<BodyScanClient>
     BodyScanClientFactory.mockReturnValue(bodyScanClient)
     service = new BodyScanService(hmppsAuthClient, BodyScanClientFactory)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)

--- a/server/data/__testutils/mocks.ts
+++ b/server/data/__testutils/mocks.ts
@@ -1,0 +1,9 @@
+import { WelcomeClient, HmppsAuthClient, BodyScanClient } from '..'
+
+jest.mock('..')
+
+export const createMockWelcomeClient = () => new WelcomeClient(null) as jest.Mocked<WelcomeClient>
+
+export const createMockHmppsAuthClient = () => new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+
+export const createMockBodyScanClient = () => new BodyScanClient(null) as jest.Mocked<BodyScanClient>

--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -2,18 +2,10 @@ import type { Express } from 'express'
 import request from 'supertest'
 import createError from 'http-errors'
 import { appWithAllRoutes } from './routes/__testutils/appSetup'
-import ExpectedArrivalsService from './services/expectedArrivalsService'
-
-jest.mock('./services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from './services/__testutils/mocks'
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 beforeEach(() => {
   app = appWithAllRoutes({ services: { expectedArrivalsService } })

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -1,14 +1,10 @@
 import type { Request, Response } from 'express'
 import { UserCaseLoad } from 'welcome'
-import UserService from '../services/userService'
-import PrisonService from '../services/prisonService'
 import populateCurrentUser from './populateCurrentUser'
+import { createMockPrisonService, createMockUserService } from '../services/__testutils/mocks'
 
-jest.mock('../services/userService')
-jest.mock('../services/expectedArrivalsService')
-
-const userService = new UserService(null, null) as jest.Mocked<UserService>
-const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
+const userService = createMockUserService()
+const prisonService = createMockPrisonService()
 
 const userCaseLoads: UserCaseLoad[] = [
   {

--- a/server/middleware/validation/movementReasonsValidation.test.ts
+++ b/server/middleware/validation/movementReasonsValidation.test.ts
@@ -1,12 +1,7 @@
 import validation from './movementReasonsValidation'
-import ImprisonmentStatusesService from '../../services/imprisonmentStatusesService'
+import { createMockImprisonmentStatusesService } from '../../services/__testutils/mocks'
 
-jest.mock('../../services/imprisonmentStatusesService')
-
-const imprisonmentStatusesService = new ImprisonmentStatusesService(
-  null,
-  null
-) as jest.Mocked<ImprisonmentStatusesService>
+const imprisonmentStatusesService = createMockImprisonmentStatusesService()
 
 describe('Movement reasons validation middleware', () => {
   beforeEach(() => {

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.test.ts
@@ -5,18 +5,10 @@ import { appWithAllRoutes, flashProvider } from '../../../__testutils/appSetup'
 
 import Role from '../../../../authentication/role'
 import config from '../../../../config'
-import { ExpectedArrivalsService } from '../../../../services'
 import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
 import { State } from '../state'
 import { createArrival, createPotentialMatch } from '../../../../data/__testutils/testObjects'
-
-jest.mock('../../../../services/expectedArrivalsService')
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
 
 const arrival = createArrival({
   prisonNumber: 'A1234AA',
@@ -27,6 +19,7 @@ const arrival = createArrival({
 })
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 beforeEach(() => {
   config.confirmNoIdentifiersEnabled = true

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/noMatchingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/noMatchingRecordsFoundController.test.ts
@@ -2,20 +2,12 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes } from '../../../__testutils/appSetup'
-import ExpectedArrivalsService from '../../../../services/expectedArrivalsService'
 import Role from '../../../../authentication/role'
 import { createArrival } from '../../../../data/__testutils/testObjects'
-
-jest.mock('../../../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 const arrival = createArrival({
   potentialMatches: [],

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.test.ts
@@ -2,22 +2,14 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes } from '../../../__testutils/appSetup'
-import ExpectedArrivalsService from '../../../../services/expectedArrivalsService'
 import Role from '../../../../authentication/role'
 import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
 import { State } from '../state'
 import { createArrival, createPotentialMatch } from '../../../../data/__testutils/testObjects'
-
-jest.mock('../../../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 const arrival = createArrival({
   prisonNumber: null,

--- a/server/routes/bookedtoday/arrivals/confirmArrival/checkAnswersController.test.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/checkAnswersController.test.ts
@@ -3,26 +3,18 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 
 import { appWithAllRoutes, user, stubCookie, flashProvider } from '../../../__testutils/appSetup'
-import { ExpectedArrivalsService, ImprisonmentStatusesService } from '../../../../services'
 import Role from '../../../../authentication/role'
 import config from '../../../../config'
 import { State } from '../state'
 import { createArrivalResponse, createNewArrival } from '../../../../data/__testutils/testObjects'
+import {
+  createMockExpectedArrivalsService,
+  createMockImprisonmentStatusesService,
+} from '../../../../services/__testutils/mocks'
 
-jest.mock('../../../../services/expectedArrivalsService')
-jest.mock('../../../../services/imprisonmentStatusesService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
-const imprisonmentStatusesService = new ImprisonmentStatusesService(
-  null,
-  null
-) as jest.Mocked<ImprisonmentStatusesService>
 let app: Express
+const imprisonmentStatusesService = createMockImprisonmentStatusesService()
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 const arrivalId = '1111-2222-3333-4444'
 const newArrival = createNewArrival()

--- a/server/routes/bookedtoday/arrivals/confirmArrival/checkAnswersController.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/checkAnswersController.ts
@@ -1,12 +1,11 @@
 import { RequestHandler } from 'express'
-import type { ImprisonmentStatusesService, ExpectedArrivalsService, RaiseAnalyticsEvent } from '../../../../services'
+import type { ImprisonmentStatusesService, ExpectedArrivalsService } from '../../../../services'
 import { State } from '../state'
 
 export default class CheckAnswersController {
   public constructor(
     private readonly expectedArrivalsService: ExpectedArrivalsService,
-    private readonly imprisonmentStatusesService: ImprisonmentStatusesService,
-    private readonly raiseAnalyticsEvent: RaiseAnalyticsEvent
+    private readonly imprisonmentStatusesService: ImprisonmentStatusesService
   ) {}
 
   public view(): RequestHandler {

--- a/server/routes/bookedtoday/arrivals/confirmArrival/confirmAddedToRollController.test.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/confirmAddedToRollController.test.ts
@@ -2,17 +2,14 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider } from '../../../__testutils/appSetup'
-import PrisonService from '../../../../services/prisonService'
 import Role from '../../../../authentication/role'
 import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
 import { State } from '../state'
 import { createPrison } from '../../../../data/__testutils/testObjects'
+import { createMockPrisonService } from '../../../../services/__testutils/mocks'
 
-jest.mock('../../../../services/expectedArrivalsService')
-jest.mock('../../../../services/prisonService')
-
-const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
 let app: Express
+const prisonService = createMockPrisonService()
 
 beforeEach(() => {
   app = appWithAllRoutes({

--- a/server/routes/bookedtoday/arrivals/confirmArrival/imprisonmentStatusesController.test.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/imprisonmentStatusesController.test.ts
@@ -3,7 +3,6 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider, stubCookie } from '../../../__testutils/appSetup'
 import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
-import ImprisonmentStatusesService from '../../../../services/imprisonmentStatusesService'
 import { State } from '../state'
 import {
   createImprisonmentStatuses,
@@ -12,13 +11,9 @@ import {
   statusWithSingleReason,
 } from '../../../../data/__testutils/testObjects'
 import Role from '../../../../authentication/role'
+import { createMockImprisonmentStatusesService } from '../../../../services/__testutils/mocks'
 
-jest.mock('../../../../services/imprisonmentStatusesService')
-
-const imprisonmentStatusesService = new ImprisonmentStatusesService(
-  null,
-  null
-) as jest.Mocked<ImprisonmentStatusesService>
+const imprisonmentStatusesService = createMockImprisonmentStatusesService()
 
 let app: Express
 const newArrival = createNewArrival()

--- a/server/routes/bookedtoday/arrivals/confirmArrival/index.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/index.ts
@@ -28,8 +28,7 @@ export default function routes(services: Services): Router {
 
   const checkAnswersController = new CheckAnswersController(
     services.expectedArrivalsService,
-    services.imprisonmentStatusesService,
-    services.raiseAnalyticsEvent
+    services.imprisonmentStatusesService
   )
 
   const confirmAddedToRollController = new ConfirmAddedToRollController(services.prisonService)

--- a/server/routes/bookedtoday/arrivals/confirmArrival/movementReasonsController.test.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/movementReasonsController.test.ts
@@ -2,20 +2,14 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, stubCookie, flashProvider } from '../../../__testutils/appSetup'
-import ImprisonmentStatusesService from '../../../../services/imprisonmentStatusesService'
 import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
 import { State } from '../state'
 import { createNewArrival, statusWithManyReasons } from '../../../../data/__testutils/testObjects'
 import Role from '../../../../authentication/role'
-
-jest.mock('../../../../services/imprisonmentStatusesService')
-
-const imprisonmentStatusesService = new ImprisonmentStatusesService(
-  null,
-  null
-) as jest.Mocked<ImprisonmentStatusesService>
+import { createMockImprisonmentStatusesService } from '../../../../services/__testutils/mocks'
 
 let app: Express
+const imprisonmentStatusesService = createMockImprisonmentStatusesService()
 
 const imprisonmentStatus = statusWithManyReasons
 const newArrival = createNewArrival()

--- a/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
@@ -3,20 +3,14 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { LocationType } from 'welcome'
 import { appWithAllRoutes, flashProvider } from '../../../__testutils/appSetup'
-import { ExpectedArrivalsService, RaiseAnalyticsEvent } from '../../../../services'
+import { RaiseAnalyticsEvent } from '../../../../services'
 import Role from '../../../../authentication/role'
 import config from '../../../../config'
 import { createArrival, createArrivalResponse, createPrisonerDetails } from '../../../../data/__testutils/testObjects'
+import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
 
-jest.mock('../../../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 const raiseAnalyticsEvent = jest.fn() as RaiseAnalyticsEvent
 
 const courtReturn = createPrisonerDetails()

--- a/server/routes/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRollController.test.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRollController.test.ts
@@ -2,13 +2,12 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider } from '../../../__testutils/appSetup'
-import PrisonService from '../../../../services/prisonService'
 import Role from '../../../../authentication/role'
 import config from '../../../../config'
+import { createMockPrisonService } from '../../../../services/__testutils/mocks'
 
-jest.mock('../../../../services/prisonService')
-const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
 let app: Express
+const prisonService = createMockPrisonService()
 
 describe('confirmCourtReturnAddedToRollController', () => {
   beforeEach(() => {

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
@@ -3,20 +3,13 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, stubCookie } from '../../__testutils/appSetup'
-import { ExpectedArrivalsService } from '../../../services'
 import Role from '../../../authentication/role'
 import { expectSettingCookie } from '../../__testutils/requestTestUtils'
 import { State } from './state'
+import { createMockExpectedArrivalsService } from '../../../services/__testutils/mocks'
 
-jest.mock('../../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 beforeEach(() => {
   app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [Role.PRISON_RECEPTION] })

--- a/server/routes/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFoundController.test.ts
@@ -6,17 +6,9 @@ import { appWithAllRoutes, flashProvider, stubCookie } from '../../../__testutil
 
 import Role from '../../../../authentication/role'
 import config from '../../../../config'
-import { ExpectedArrivalsService } from '../../../../services'
 import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
 import { State } from '../state'
-
-jest.mock('../../../../services/expectedArrivalsService')
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
 
 const searchDetails = {
   firstName: 'Jamie',
@@ -41,6 +33,7 @@ const potentialMatches = [
   },
 ]
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 beforeEach(() => {
   config.confirmNoIdentifiersEnabled = true

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
@@ -3,21 +3,14 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, stubCookie } from '../../../../__testutils/appSetup'
-import { ExpectedArrivalsService } from '../../../../../services'
 import Role from '../../../../../authentication/role'
 import config from '../../../../../config'
 import { expectSettingCookie } from '../../../../__testutils/requestTestUtils'
 import { State } from '../../state'
+import { createMockExpectedArrivalsService } from '../../../../../services/__testutils/mocks'
 
-jest.mock('../../../../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 const searchDetails = {
   firstName: 'James',

--- a/server/routes/bookedtoday/choosePrisonerController.test.ts
+++ b/server/routes/bookedtoday/choosePrisonerController.test.ts
@@ -6,20 +6,11 @@ import * as cheerio from 'cheerio'
 import { user, appWithAllRoutes, stubCookie } from '../__testutils/appSetup'
 import { expectSettingCookie } from '../__testutils/requestTestUtils'
 import config from '../../config'
-
-import ExpectedArrivalsService from '../../services/expectedArrivalsService'
 import { State } from './arrivals/state'
-
-jest.mock('../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../services/__testutils/mocks'
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 beforeEach(() => {
   stubCookie(State.newArrival, {

--- a/server/routes/bookedtoday/transfers/checkTransferController.test.ts
+++ b/server/routes/bookedtoday/transfers/checkTransferController.test.ts
@@ -2,16 +2,14 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider } from '../../__testutils/appSetup'
-import { TransfersService, RaiseAnalyticsEvent } from '../../../services'
-
+import { RaiseAnalyticsEvent } from '../../../services'
 import Role from '../../../authentication/role'
 import config from '../../../config'
 import { createTransfer } from '../../../data/__testutils/testObjects'
+import { createMockTransfersService } from '../../../services/__testutils/mocks'
 
-jest.mock('../../../services/transfersService')
-
-const transfersService = new TransfersService(null, null) as jest.Mocked<TransfersService>
 let app: Express
+const transfersService = createMockTransfersService()
 const raiseAnalyticsEvent = jest.fn() as RaiseAnalyticsEvent
 
 beforeEach(() => {

--- a/server/routes/bookedtoday/transfers/confirmTransferAddedToRollController.test.ts
+++ b/server/routes/bookedtoday/transfers/confirmTransferAddedToRollController.test.ts
@@ -2,12 +2,11 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider } from '../../__testutils/appSetup'
-import PrisonService from '../../../services/prisonService'
 import Role from '../../../authentication/role'
+import { createMockPrisonService } from '../../../services/__testutils/mocks'
 
-jest.mock('../../../services/prisonService')
-const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
 let app: Express
+const prisonService = createMockPrisonService()
 
 beforeEach(() => {
   app = appWithAllRoutes({

--- a/server/routes/bookedtoday/unexpectedArrivals/multipleExistingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/multipleExistingRecordsFoundController.test.ts
@@ -5,17 +5,9 @@ import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider, stubCookie } from '../../__testutils/appSetup'
 
 import Role from '../../../authentication/role'
-import { ExpectedArrivalsService } from '../../../services'
 import { State } from '../arrivals/state'
 import { expectSettingCookie } from '../../__testutils/requestTestUtils'
-
-jest.mock('../../../services/expectedArrivalsService')
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../../services/__testutils/mocks'
 
 const searchDetails = {
   firstName: 'Jim',
@@ -41,6 +33,7 @@ const potentialMatches = [
   },
 ]
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 beforeEach(() => {
   app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [Role.PRISON_RECEPTION] })

--- a/server/routes/bookedtoday/unexpectedArrivals/searchForExistingRecordsController.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/searchForExistingRecordsController.test.ts
@@ -3,20 +3,15 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider } from '../../__testutils/appSetup'
-import { ExpectedArrivalsService } from '../../../services'
 import Role from '../../../authentication/role'
 import config from '../../../config'
 import * as State from '../arrivals/state'
+import { createMockExpectedArrivalsService } from '../../../services/__testutils/mocks'
 
-jest.mock('../../../services/expectedArrivalsService')
 jest.mock('../arrivals/state')
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 const searchInputDetails = {
   firstName: 'James',

--- a/server/routes/bookedtoday/unexpectedArrivals/singleExistingRecordFoundController.test.ts
+++ b/server/routes/bookedtoday/unexpectedArrivals/singleExistingRecordFoundController.test.ts
@@ -2,20 +2,12 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, stubCookies, stubCookie } from '../../__testutils/appSetup'
-import ExpectedArrivalsService from '../../../services/expectedArrivalsService'
 import Role from '../../../authentication/role'
 import { State } from '../arrivals/state'
-
-jest.mock('../../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../../services/__testutils/mocks'
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 beforeEach(() => {
   app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [Role.PRISON_RECEPTION] })

--- a/server/routes/prisonerController.test.ts
+++ b/server/routes/prisonerController.test.ts
@@ -1,20 +1,11 @@
 import type { Express } from 'express'
 import { Readable } from 'stream'
 import request from 'supertest'
+import { createMockExpectedArrivalsService } from '../services/__testutils/mocks'
 import { appWithAllRoutes } from './__testutils/appSetup'
-import ExpectedArrivalsService from '../services/expectedArrivalsService'
-
-jest.mock('../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
 
 let app: Express
-
+const expectedArrivalsService = createMockExpectedArrivalsService()
 const image = {}
 
 beforeEach(() => {

--- a/server/routes/recentArrivals/recentArrivalsController.test.ts
+++ b/server/routes/recentArrivals/recentArrivalsController.test.ts
@@ -4,21 +4,14 @@ import moment from 'moment'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, user } from '../__testutils/appSetup'
 import Role from '../../authentication/role'
-import ExpectedArrivalsService from '../../services/expectedArrivalsService'
+
 import { createRecentArrival } from '../../data/__testutils/testObjects'
 import { expectSettingCookie } from '../__testutils/requestTestUtils'
 import { State } from './state'
-
-jest.mock('../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../services/__testutils/mocks'
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 const today = moment().startOf('day')
 const oneDayAgo = moment().subtract(1, 'days').startOf('day')

--- a/server/routes/recentArrivals/recentArrivalsSearchController.test.ts
+++ b/server/routes/recentArrivals/recentArrivalsSearchController.test.ts
@@ -3,21 +3,13 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, user, stubCookie } from '../__testutils/appSetup'
 import Role from '../../authentication/role'
-import ExpectedArrivalsService from '../../services/expectedArrivalsService'
 import { createRecentArrival } from '../../data/__testutils/testObjects'
 import { expectSettingCookie } from '../__testutils/requestTestUtils'
 import { State } from './state'
-
-jest.mock('../../services/expectedArrivalsService')
-
-const expectedArrivalsService = new ExpectedArrivalsService(
-  null,
-  null,
-  null,
-  null
-) as jest.Mocked<ExpectedArrivalsService>
+import { createMockExpectedArrivalsService } from '../../services/__testutils/mocks'
 
 let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
 
 const recentArrivals = [
   createRecentArrival({ firstName: 'John', lastName: 'Doe', prisonNumber: 'A1234BC' }),

--- a/server/routes/temporaryabsences/checkTemporaryAbsenceController.test.ts
+++ b/server/routes/temporaryabsences/checkTemporaryAbsenceController.test.ts
@@ -2,15 +2,15 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider } from '../__testutils/appSetup'
-import { TemporaryAbsencesService, RaiseAnalyticsEvent } from '../../services'
+import { RaiseAnalyticsEvent } from '../../services'
 
 import Role from '../../authentication/role'
 import config from '../../config'
 import { createTemporaryAbsence } from '../../data/__testutils/testObjects'
+import { createMockTemporaryAbsencesService } from '../../services/__testutils/mocks'
 
-jest.mock('../../services/temporaryAbsencesService')
-const temporaryAbsencesService = new TemporaryAbsencesService(null, null, null) as jest.Mocked<TemporaryAbsencesService>
 let app: Express
+const temporaryAbsencesService = createMockTemporaryAbsencesService()
 const raiseAnalyticsEvent = jest.fn() as RaiseAnalyticsEvent
 
 beforeEach(() => {

--- a/server/routes/temporaryabsences/confirmTemporaryAbsenceAddedToRollController.test.ts
+++ b/server/routes/temporaryabsences/confirmTemporaryAbsenceAddedToRollController.test.ts
@@ -2,13 +2,12 @@ import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider } from '../__testutils/appSetup'
-import PrisonService from '../../services/prisonService'
 import Role from '../../authentication/role'
 import config from '../../config'
+import { createMockPrisonService } from '../../services/__testutils/mocks'
 
-jest.mock('../../services/prisonService')
-const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
 let app: Express
+const prisonService = createMockPrisonService()
 
 describe('confirmTemporaryAbsenceAddedToRollController', () => {
   beforeEach(() => {

--- a/server/routes/temporaryabsences/temporaryAbsencesController.test.ts
+++ b/server/routes/temporaryabsences/temporaryAbsencesController.test.ts
@@ -3,17 +3,14 @@ import request from 'supertest'
 import * as cheerio from 'cheerio'
 import { type TemporaryAbsence } from 'welcome'
 import { appWithAllRoutes, user } from '../__testutils/appSetup'
-import TemporaryAbsencesService from '../../services/temporaryAbsencesService'
 import Role from '../../authentication/role'
 import config from '../../config'
 import { withBodyScanInfo, createTemporaryAbsence } from '../../data/__testutils/testObjects'
 import type { WithBodyScanInfo } from '../../services/bodyScanInfoDecorator'
-
-jest.mock('../../services/temporaryAbsencesService')
-
-const temporaryAbsencesService = new TemporaryAbsencesService(null, null, null) as jest.Mocked<TemporaryAbsencesService>
+import { createMockTemporaryAbsencesService } from '../../services/__testutils/mocks'
 
 let app: Express
+const temporaryAbsencesService = createMockTemporaryAbsencesService()
 
 const temporaryAbsences: WithBodyScanInfo<TemporaryAbsence>[] = [
   withBodyScanInfo(createTemporaryAbsence()),

--- a/server/services/__testutils/mocks.ts
+++ b/server/services/__testutils/mocks.ts
@@ -1,0 +1,29 @@
+import {
+  ExpectedArrivalsService,
+  ImprisonmentStatusesService,
+  PrisonService,
+  TransfersService,
+  BodyScanInfoDecorator,
+  TemporaryAbsencesService,
+  UserService,
+} from '..'
+
+jest.mock('..')
+
+export const createMockExpectedArrivalsService = () =>
+  new ExpectedArrivalsService(null, null, null, null) as jest.Mocked<ExpectedArrivalsService>
+
+export const createMockImprisonmentStatusesService = () =>
+  new ImprisonmentStatusesService(null, null) as jest.Mocked<ImprisonmentStatusesService>
+
+export const createMockPrisonService = () => new PrisonService(null, null) as jest.Mocked<PrisonService>
+
+export const createMockTransfersService = () => new TransfersService(null, null) as jest.Mocked<TransfersService>
+
+export const createMockBodyScanInfoDecorator = () =>
+  new BodyScanInfoDecorator(null, null) as jest.Mocked<BodyScanInfoDecorator>
+
+export const createMockTemporaryAbsencesService = () =>
+  new TemporaryAbsencesService(null, null, null) as jest.Mocked<TemporaryAbsencesService>
+
+export const createMockUserService = () => new UserService(null, null) as jest.Mocked<UserService>

--- a/server/services/bodyScanInfoDecorator.test.ts
+++ b/server/services/bodyScanInfoDecorator.test.ts
@@ -1,24 +1,21 @@
 import { BodyScanStatus } from 'body-scan'
-import { HmppsAuthClient, BodyScanClient } from '../data'
+import { createMockBodyScanClient, createMockHmppsAuthClient } from '../data/__testutils/mocks'
 
 import { BodyScanInfoDecorator } from './bodyScanInfoDecorator'
 
-jest.mock('../data')
 jest.mock('./raiseAnalyticsEvent')
 
 const token = 'some token'
 
 describe('BodyScanInfoDecorater', () => {
-  let bodyScanClient: jest.Mocked<BodyScanClient>
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const bodyScanClient = createMockBodyScanClient()
   let service: BodyScanInfoDecorator
 
   const BodyScanClientFactory = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    bodyScanClient = new BodyScanClient(null) as jest.Mocked<BodyScanClient>
     BodyScanClientFactory.mockReturnValue(bodyScanClient)
     service = new BodyScanInfoDecorator(hmppsAuthClient, BodyScanClientFactory)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)

--- a/server/services/expectedArrivalsService.test.ts
+++ b/server/services/expectedArrivalsService.test.ts
@@ -2,8 +2,6 @@ import moment from 'moment'
 import { type Arrival, LocationType } from 'welcome'
 import { BodyScanStatus } from 'body-scan'
 import ExpectedArrivalsService from './expectedArrivalsService'
-import HmppsAuthClient from '../data/hmppsAuthClient'
-import WelcomeClient from '../data/welcomeClient'
 import { NewArrival } from '../routes/bookedtoday/arrivals/state'
 import { raiseAnalyticsEvent } from './raiseAnalyticsEvent'
 import {
@@ -17,19 +15,17 @@ import {
   createTransfer,
   withBodyScanInfo,
 } from '../data/__testutils/testObjects'
-import { BodyScanInfoDecorator } from './bodyScanInfoDecorator'
+import { createMockHmppsAuthClient, createMockWelcomeClient } from '../data/__testutils/mocks'
+import { createMockBodyScanInfoDecorator } from './__testutils/mocks'
 
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/welcomeClient')
 jest.mock('./raiseAnalyticsEvent')
-jest.mock('./bodyScanInfoDecorator')
 
 const token = 'some token'
 
 describe('Expected arrivals service', () => {
-  let welcomeClient: jest.Mocked<WelcomeClient>
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
-  let bodyScanInfoDecorator: jest.Mocked<BodyScanInfoDecorator>
+  const welcomeClient = createMockWelcomeClient()
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const bodyScanInfoDecorator = createMockBodyScanInfoDecorator()
   let service: ExpectedArrivalsService
 
   const WelcomeClientFactory = jest.fn()
@@ -40,9 +36,6 @@ describe('Expected arrivals service', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    welcomeClient = new WelcomeClient(null) as jest.Mocked<WelcomeClient>
-    bodyScanInfoDecorator = new BodyScanInfoDecorator(null, null) as jest.Mocked<BodyScanInfoDecorator>
     WelcomeClientFactory.mockReturnValue(welcomeClient)
     service = new ExpectedArrivalsService(
       hmppsAuthClient,

--- a/server/services/imprisonmentStatusesService.test.ts
+++ b/server/services/imprisonmentStatusesService.test.ts
@@ -1,16 +1,12 @@
 import ImprisonmentStatusesService from './imprisonmentStatusesService'
-import HmppsAuthClient from '../data/hmppsAuthClient'
-import WelcomeClient from '../data/welcomeClient'
 import { createImprisonmentStatuses } from '../data/__testutils/testObjects'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/welcomeClient')
+import { createMockHmppsAuthClient, createMockWelcomeClient } from '../data/__testutils/mocks'
 
 const token = 'some token'
 
 describe('Imprisonment statuses service', () => {
-  let welcomeClient: jest.Mocked<WelcomeClient>
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  const welcomeClient = createMockWelcomeClient()
+  const hmppsAuthClient = createMockHmppsAuthClient()
   let service: ImprisonmentStatusesService
 
   const WelcomeClientFactory = jest.fn()
@@ -19,8 +15,6 @@ describe('Imprisonment statuses service', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    welcomeClient = new WelcomeClient(null) as jest.Mocked<WelcomeClient>
     WelcomeClientFactory.mockReturnValue(welcomeClient)
     service = new ImprisonmentStatusesService(hmppsAuthClient, WelcomeClientFactory)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -43,6 +43,7 @@ export const services = () => {
 export type Services = ReturnType<typeof services>
 
 export {
+  BodyScanInfoDecorator,
   UserService,
   ExpectedArrivalsService,
   TemporaryAbsencesService,

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -1,16 +1,12 @@
 import PrisonService from './prisonService'
-import HmppsAuthClient from '../data/hmppsAuthClient'
-import WelcomeClient from '../data/welcomeClient'
 import { createPrison } from '../data/__testutils/testObjects'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/welcomeClient')
+import { createMockHmppsAuthClient, createMockWelcomeClient } from '../data/__testutils/mocks'
 
 const token = 'some token'
 
 describe('Expected arrivals service', () => {
-  const welcomeClient = new WelcomeClient(null) as jest.Mocked<WelcomeClient>
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const welcomeClient = createMockWelcomeClient()
+  const hmppsAuthClient = createMockHmppsAuthClient()
   let service: PrisonService
 
   const WelcomeClientFactory = jest.fn()

--- a/server/services/temporaryAbsencesService.test.ts
+++ b/server/services/temporaryAbsencesService.test.ts
@@ -1,20 +1,15 @@
 import { BodyScanStatus } from 'body-scan'
 import TemporaryAbsencesService from './temporaryAbsencesService'
-import HmppsAuthClient from '../data/hmppsAuthClient'
-import WelcomeClient from '../data/welcomeClient'
 import { createTemporaryAbsence, withBodyScanInfo } from '../data/__testutils/testObjects'
-import { BodyScanInfoDecorator } from './bodyScanInfoDecorator'
-
-jest.mock('./bodyScanInfoDecorator')
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/welcomeClient')
+import { createMockHmppsAuthClient, createMockWelcomeClient } from '../data/__testutils/mocks'
+import { createMockBodyScanInfoDecorator } from './__testutils/mocks'
 
 const token = 'some token'
 
 describe('Temporary absences service', () => {
-  const welcomeClient = new WelcomeClient(null) as jest.Mocked<WelcomeClient>
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-  const bodyScanInfoDecorator = new BodyScanInfoDecorator(null, null) as jest.Mocked<BodyScanInfoDecorator>
+  const welcomeClient = createMockWelcomeClient()
+  const hmppsAuthClient = createMockHmppsAuthClient()
+  const bodyScanInfoDecorator = createMockBodyScanInfoDecorator()
   let service: TemporaryAbsencesService
 
   const WelcomeClientFactory = jest.fn()

--- a/server/services/transfersService.test.ts
+++ b/server/services/transfersService.test.ts
@@ -1,26 +1,20 @@
 import TransfersService from './transfersService'
-import HmppsAuthClient from '../data/hmppsAuthClient'
-import WelcomeClient from '../data/welcomeClient'
 import { createTransfer } from '../data/__testutils/testObjects'
-
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/welcomeClient')
+import { createMockHmppsAuthClient, createMockWelcomeClient } from '../data/__testutils/mocks'
 
 const token = 'some token'
 
 const transfer = createTransfer()
 
 describe('Transfers service', () => {
-  let welcomeClient: jest.Mocked<WelcomeClient>
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  const welcomeClient = createMockWelcomeClient()
+  const hmppsAuthClient = createMockHmppsAuthClient()
   let service: TransfersService
 
   const WelcomeClientFactory = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    welcomeClient = new WelcomeClient(null) as jest.Mocked<WelcomeClient>
     WelcomeClientFactory.mockReturnValue(welcomeClient)
     service = new TransfersService(hmppsAuthClient, WelcomeClientFactory)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,16 +1,13 @@
 import UserService from './userService'
-import HmppsAuthClient from '../data/hmppsAuthClient'
-import WelcomeClient from '../data/welcomeClient'
-import { createUser, createUserCaseLoad } from '../data/__testutils/testObjects'
 
-jest.mock('../data/hmppsAuthClient')
-jest.mock('../data/welcomeClient')
+import { createUser, createUserCaseLoad } from '../data/__testutils/testObjects'
+import { createMockHmppsAuthClient, createMockWelcomeClient } from '../data/__testutils/mocks'
 
 const token = 'some token'
 
 describe('User service', () => {
-  const welcomeClient = new WelcomeClient(null) as jest.Mocked<WelcomeClient>
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const welcomeClient = createMockWelcomeClient()
+  const hmppsAuthClient = createMockHmppsAuthClient()
   let service: UserService
 
   const WelcomeClientFactory = jest.fn()


### PR DESCRIPTION
Everytime the dependencies for a service change, it propagates through all the test files. Moved the creation of mocks to central files which should prevent this propagation and simplifies the set up in tests