### PR TITLE
DCS-1686 body scan confirmation page css fix

### DIFF
--- a/server/views/pages/bodyscans/scanConfirmation.njk
+++ b/server/views/pages/bodyscans/scanConfirmation.njk
@@ -14,7 +14,7 @@
                     } 
                 }) }}
 
-                <h2 class="govuk-heading-m">Add more information about this body scan</h2>
+                <h2 class="govuk-heading-m govuk-!-margin-top-6">Add more information about this body scan</h2>
                 <p>
                     <a class="govuk-body govuk-link govuk-link--no-visited-state" href="{{ dpsUrl }}/prisoner/{{prisonNumber}}/add-case-note" data-qa="add-case-note">
                                 Add a case note on their profile


### PR DESCRIPTION
Small css fix to add more space between banner and Add more information about this body scan h2:

From
<img width="749" alt="Screenshot 2022-08-10 at 14 09 59" src="https://user-images.githubusercontent.com/48809053/183909937-e1d1cd17-67bd-49b7-82c6-6c031564322b.png">

To
<img width="762" alt="Screenshot 2022-08-10 at 14 10 04" src="https://user-images.githubusercontent.com/48809053/183909944-67c5ac3b-b86a-4d72-acfc-9e71d7ec9183.png">