### PR TITLE
DCS-1691: ♻️ Move to using DPS backlink endpoint for Case Notes

### DIFF
--- a/integration_tests/pages/bodyscan/bodyScanConfirmation.ts
+++ b/integration_tests/pages/bodyscan/bodyScanConfirmation.ts
@@ -12,7 +12,7 @@ export default class BodyScanConfirmation extends Page {
       Page.checkLink(
         cy.get(`[data-qa=add-case-note]`),
         'Add a case note on their profile',
-        `https://digital-dev.prison.service.justice.gov.uk/prisoner/${prisonNumber}/add-case-note`
+        `https://digital-dev.prison.service.justice.gov.uk/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/${prisonNumber}/add-case-note`
       ),
   })
 }

--- a/integration_tests/pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll.ts
+++ b/integration_tests/pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll.ts
@@ -35,7 +35,7 @@ export default class ConfirmAddedToRollPage extends Page {
       Page.checkLink(
         cy.get(`[data-qa=add-case-note]`),
         'Add a case note on their profile',
-        `https://digital-dev.prison.service.justice.gov.uk/prisoner/${prisonNumber}/add-case-note`
+        `https://digital-dev.prison.service.justice.gov.uk/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/${prisonNumber}/add-case-note`
       ),
   })
 

--- a/integration_tests/pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll.ts
+++ b/integration_tests/pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll.ts
@@ -10,7 +10,7 @@ export default class ConfirmCourtReturnAddedToRollPage extends Page {
       Page.checkLink(
         cy.get(`[data-qa=add-case-note]`),
         'Add a case note on their profile',
-        `https://digital-dev.prison.service.justice.gov.uk/prisoner/${prisonNumber}/add-case-note`
+        `https://digital-dev.prison.service.justice.gov.uk/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/${prisonNumber}/add-case-note`
       ),
   })
 

--- a/integration_tests/pages/bookedtoday/transfers/confirmTransferAddedToRoll.ts
+++ b/integration_tests/pages/bookedtoday/transfers/confirmTransferAddedToRoll.ts
@@ -10,7 +10,7 @@ export default class ConfirmTransferAddedToRollPage extends Page {
       Page.checkLink(
         cy.get(`[data-qa=add-case-note]`),
         'Add a case note on their profile',
-        `https://digital-dev.prison.service.justice.gov.uk/prisoner/${prisonNumber}/add-case-note`
+        `https://digital-dev.prison.service.justice.gov.uk/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/${prisonNumber}/add-case-note`
       ),
   })
 

--- a/integration_tests/pages/temporaryabsences/confirmTemporaryAbsenceAddedToRoll.ts
+++ b/integration_tests/pages/temporaryabsences/confirmTemporaryAbsenceAddedToRoll.ts
@@ -15,7 +15,7 @@ export default class ConfirmTemporaryAbsenceAddedToRollPage extends Page {
       Page.checkLink(
         cy.get(`[data-qa=add-case-note]`),
         'Add a case note on their profile',
-        `https://digital-dev.prison.service.justice.gov.uk/prisoner/${prisonNumber}/add-case-note`
+        `https://digital-dev.prison.service.justice.gov.uk/save-backlink?service=welcome-people-into-prison&returnPath=/=&redirectPath=/prisoner/${prisonNumber}/add-case-note`
       ),
   })
 

--- a/server/views/pages/bodyscans/scanConfirmation.njk
+++ b/server/views/pages/bodyscans/scanConfirmation.njk
@@ -10,22 +10,24 @@
                     titleText: 'Body scan recorded',
                     html: "<strong>" + prisonerDetails.firstName | escape + " " + prisonerDetails.lastName | escape + "</strong><br>" + bodyScan.date | formatDate("dddd D MMMM") + "<br>" + bodyScan.reason | replace("_", " ") | capitalize + " - " + bodyScan.result | lower,
                     attributes: {
-                    'data-qa': 'confirmation-banner'
-                    } 
+                        'data-qa': 'confirmation-banner'
+                    }
                 }) }}
 
                 <h2 class="govuk-heading-m govuk-!-margin-top-6">Add more information about this body scan</h2>
                 <p>
-                    <a class="govuk-body govuk-link govuk-link--no-visited-state" href="{{ dpsUrl }}/prisoner/{{prisonNumber}}/add-case-note" data-qa="add-case-note">
-                                Add a case note on their profile
-                            </a>
+                    <a class="govuk-body govuk-link govuk-link--no-visited-state"
+                       href="{{ dpsUrl }}/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/{{ prisonNumber }}/add-case-note"
+                       data-qa="add-case-note">
+                        Add a case note on their profile
+                    </a>
                 </p>
                 <p class="govuk-!-margin-top-9">
                     {{ govukButton({
-                    classes: "govuk-button govuk-!-margin-bottom-6",
-                    href: "/prisoners/" + prisonNumber,
-                    text: "Back to prisoner summary",
-                    attributes: {'data-qa': 'back-to-prisoner-summary'}
+                        classes: "govuk-button govuk-!-margin-bottom-6",
+                        href: "/prisoners/" + prisonNumber,
+                        text: "Back to prisoner summary",
+                        attributes: {'data-qa': 'back-to-prisoner-summary'}
                     }) }}
                 </p>
             </div>

--- a/server/views/pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll.njk
+++ b/server/views/pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll.njk
@@ -4,51 +4,53 @@
 {% set pageTitle = "This person has been added to the establishment roll" %}
 
 {% block content %}
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        {{ govukPanel({
-        titleText: firstName + " " + lastName + " " + "has been added to the establishment roll",
-        html: "Prison number<br><strong>" + prisonNumber | escape + "</strong>",
-        attributes: {
-          'data-qa': 'confirmation-banner'
-        } 
-      }) }}
+    <div class="govuk-width-container">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                {{ govukPanel({
+                    titleText: firstName + " " + lastName + " " + "has been added to the establishment roll",
+                    html: "Prison number<br><strong>" + prisonNumber | escape + "</strong>",
+                    attributes: {
+                        'data-qa': 'confirmation-banner'
+                    }
+                }) }}
 
-        <p data-qa="confirmation-paragraph">{{ firstName}}
-          {{ lastName }} is now part of the {{ prison.description }} establishment roll.</p>
+                <p data-qa="confirmation-paragraph">{{ firstName }}
+                    {{ lastName }} is now part of the {{ prison.description }} establishment roll.</p>
 
-        <p data-qa="location-paragraph">Their location is {{ location }}.</p>
+                <p data-qa="location-paragraph">Their location is {{ location }}.</p>
 
-        <h2 class="govuk-heading-m">Add more information about this person</h2>
-        <p>
-          <a class="govuk-body govuk-link govuk-link--no-visited-state" href="{{ dpsUrl }}/prisoner/{{prisonNumber}}/add-case-note" data-qa="add-case-note">
-            Add a case note on their profile
-          </a>
-        </p>
+                <h2 class="govuk-heading-m">Add more information about this person</h2>
+                <p>
+                    <a class="govuk-body govuk-link govuk-link--no-visited-state"
+                       href="{{ dpsUrl }}/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/{{ prisonNumber }}/add-case-note"
+                       data-qa="add-case-note">
+                        Add a case note on their profile
+                    </a>
+                </p>
 
-        <div class="govuk-button-group govuk-!-padding-top-6">
-          {{ govukButton({
-            text: "Add another prisoner to the roll",
-            href: "/confirm-arrival/choose-prisoner",
-            attributes: {
-              'data-qa': 'add-another-to-roll'
-            } 
+                <div class="govuk-button-group govuk-!-padding-top-6">
+                    {{ govukButton({
+                        text: "Add another prisoner to the roll",
+                        href: "/confirm-arrival/choose-prisoner",
+                        attributes: {
+                            'data-qa': 'add-another-to-roll'
+                        }
 
-          }) }}
+                    }) }}
 
-          {{ govukButton({
-            text: "View establishment roll",
-            classes: "govuk-button--secondary",
-            href: dpsUrl + "/establishment-roll",
-            attributes: {
-              'data-qa': 'view-establishment-roll',
-              'target': '_blank'
-            } 
-          }) }}
+                    {{ govukButton({
+                        text: "View establishment roll",
+                        classes: "govuk-button--secondary",
+                        href: dpsUrl + "/establishment-roll",
+                        attributes: {
+                            'data-qa': 'view-establishment-roll',
+                            'target': '_blank'
+                        }
+                    }) }}
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
 
 {% endblock %}

--- a/server/views/pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll.njk
+++ b/server/views/pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll.njk
@@ -10,14 +10,16 @@
                     titleText: firstName + " " + lastName + " " + "has returned to " + prison.description,
                     html: "Prison number<br><strong>" + prisonNumber | escape + "</strong>",
                     attributes: {
-                    'data-qa': 'confirmation-banner'
-                    } 
+                        'data-qa': 'confirmation-banner'
+                    }
                 }) }}
                 <p data-qa="confirmation-paragraph">{{ firstName }} {{ lastName }} is on the establishment roll.</p>
                 <p data-qa="location-paragraph">Their location is {{ location }}.</p>
                 <h2 class="govuk-heading-m">Add more information about this person</h2>
                 <p>
-                    <a class="govuk-body govuk-link govuk-link--no-visited-state" href="{{ dpsUrl }}/prisoner/{{ prisonNumber }}/add-case-note" data-qa="add-case-note">
+                    <a class="govuk-body govuk-link govuk-link--no-visited-state"
+                       href="{{ dpsUrl }}/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/{{ prisonNumber }}/add-case-note"
+                       data-qa="add-case-note">
                         Add a case note on their profile
                     </a>
                 </p>
@@ -27,7 +29,7 @@
                         href: "/confirm-arrival/choose-prisoner",
                         attributes: {
                             'data-qa': 'add-another-to-roll'
-                        } 
+                        }
 
                     }) }}
                     {{ govukButton({
@@ -37,9 +39,9 @@
                         attributes: {
                             'data-qa': 'view-establishment-roll',
                             'target': '_blank'
-                        } 
+                        }
                     }) }}
-                </div>       
+                </div>
             </div>
         </div>
     </div>

--- a/server/views/pages/bookedtoday/transfers/confirmTransferAddedToRoll.njk
+++ b/server/views/pages/bookedtoday/transfers/confirmTransferAddedToRoll.njk
@@ -10,41 +10,44 @@
                     titleText: firstName + " " + lastName + " " + "has been added to the establishment roll",
                     html: "Prison number<br><strong>" + prisonNumber | escape + "</strong>",
                     attributes: {
-                    'data-qa': 'confirmation-banner'
-                    } 
+                        'data-qa': 'confirmation-banner'
+                    }
                 }) }}
 
-                <p data-qa="confirmation-paragraph">{{ firstName}} {{ lastName }} is now part of the {{ prison.description }} establishment roll.</p>
+                <p data-qa="confirmation-paragraph">{{ firstName }} {{ lastName }} is now part of
+                    the {{ prison.description }} establishment roll.</p>
 
                 <p data-qa="location-paragraph">Their location is {{ location }}.</p>
 
                 <h2 class="govuk-heading-m">Add more information about this person</h2>
-                    <p>
-                        <a class="govuk-body govuk-link govuk-link--no-visited-state" href="{{ dpsUrl }}/prisoner/{{prisonNumber}}/add-case-note" data-qa="add-case-note">
-                            Add a case note on their profile
-                        </a>
-                    </p>
+                <p>
+                    <a class="govuk-body govuk-link govuk-link--no-visited-state"
+                       href="{{ dpsUrl }}/save-backlink?service=welcome-people-into-prison&returnPath=/confirm-arrival/choose-prisoner&redirectPath=/prisoner/{{ prisonNumber }}/add-case-note"
+                       data-qa="add-case-note">
+                        Add a case note on their profile
+                    </a>
+                </p>
 
-                    <div class="govuk-button-group govuk-!-padding-top-6">
-                        {{ govukButton({
-                            text: "Add another prisoner to the roll",
-                            href: "/confirm-arrival/choose-prisoner",
-                            attributes: {
-                                'data-qa': 'add-another-to-roll'
-                            } 
+                <div class="govuk-button-group govuk-!-padding-top-6">
+                    {{ govukButton({
+                        text: "Add another prisoner to the roll",
+                        href: "/confirm-arrival/choose-prisoner",
+                        attributes: {
+                            'data-qa': 'add-another-to-roll'
+                        }
 
-                        }) }}
+                    }) }}
 
-                        {{ govukButton({
-                            text: "View establishment roll",
-                            classes: "govuk-button--secondary",
-                            href: dpsUrl + "/establishment-roll",
-                            attributes: {
-                                'data-qa': 'view-establishment-roll',
-                                'target': '_blank'
-                            } 
-                        }) }}
-                    </div>
+                    {{ govukButton({
+                        text: "View establishment roll",
+                        classes: "govuk-button--secondary",
+                        href: dpsUrl + "/establishment-roll",
+                        attributes: {
+                            'data-qa': 'view-establishment-roll',
+                            'target': '_blank'
+                        }
+                    }) }}
+                </div>
             </div>
         </div>
     </div>

--- a/server/views/pages/temporaryabsences/confirmTemporaryAbsenceAddedToRoll.njk
+++ b/server/views/pages/temporaryabsences/confirmTemporaryAbsenceAddedToRoll.njk
@@ -10,20 +10,23 @@
                     titleText: firstName + " " + lastName + " " + "has returned to " + prison.description,
                     html: "Prison number<br><strong>" + prisonNumber | escape + "</strong>",
                     attributes: {
-                    'data-qa': 'confirmation-banner'
-                    } 
+                        'data-qa': 'confirmation-banner'
+                    }
                 }) }}
 
-                <p data-qa="confirmation-paragraph">{{ firstName}} {{ lastName }} is on the establishment roll.</p>
-                
+                <p data-qa="confirmation-paragraph">{{ firstName }} {{ lastName }} is on the establishment roll.</p>
+
                 <p data-qa="location-paragraph">Their location is {{ location }}.</p>
 
                 <h2 class="govuk-heading-m">Add more information about this person</h2>
-                        <p>
-                            <a class="govuk-body govuk-link govuk-link--no-visited-state" href="{{ dpsUrl }}/prisoner/{{prisonNumber}}/add-case-note" data-qa="add-case-note">
-                                Add a case note on their profile
-                            </a>
-                        </p>
+                <p>
+                    <a class="govuk-body govuk-link govuk-link--no-visited-state"
+                       href="{{ dpsUrl }}/save-backlink?service=welcome-people-into-prison&returnPath=/=&redirectPath=/prisoner/{{ prisonNumber }}/add-case-note"
+                       data-qa="add-case-note"
+                    >
+                        Add a case note on their profile
+                    </a>
+                </p>
 
                 <div class="govuk-button-group govuk-!-padding-top-6">
                     {{ govukButton({
@@ -31,7 +34,7 @@
                         href: "/",
                         attributes: {
                             'data-qa': 'back-to-new-arrivals'
-                        } 
+                        }
 
                     }) }}
 
@@ -42,7 +45,7 @@
                         attributes: {
                             'data-qa': 'view-establishment-roll',
                             'target': '_blank'
-                        } 
+                        }
                     }) }}
                 </div>
             </div>


### PR DESCRIPTION
PR to update the **Add a case note** link to use the DPS backlink URL so users aren't dead-ended after adding a case note.

There are essentially only two link updates here
- Update Temporary Absence Confirmation so the return URL is **/**
- Update every other Confirmation Page so the return URL is **/confirm-arrival/choose-prisoner**

Apologies for the mass indentations, seems like our standard is four indents hadn't been applied in some instances 👀 I'd recommend hiding whitespace changes in Github to see the actual changes in the .njk files😄 