### PR TITLE
DCS-1786 extracting out logic around deriving match type

### DIFF
--- a/server/data/__testutils/testObjects.ts
+++ b/server/data/__testutils/testObjects.ts
@@ -18,10 +18,16 @@ import {
 import { BodyScanStatus } from 'body-scan'
 import type { NewArrival } from '../../routes/bookedtoday/arrivals/state'
 import type { User } from '../hmppsAuthClient'
+import { MatchType } from '../../services/matchTypeDecorator'
 
 export const withBodyScanInfo = <T>(t: T, { bodyScanStatus = BodyScanStatus.OK_TO_SCAN } = {}) => ({
   ...t,
   bodyScanStatus,
+})
+
+export const withMatchType = <T>(t: T, { matchType = MatchType.SINGLE_MATCH } = {}) => ({
+  ...t,
+  matchType,
 })
 
 export const createArrival = ({

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.test.ts
@@ -9,14 +9,18 @@ import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
 import { State } from '../state'
 import { createArrival, createPotentialMatch } from '../../../../data/__testutils/testObjects'
 import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
+import { MatchType } from '../../../../services/matchTypeDecorator'
 
-const arrival = createArrival({
-  prisonNumber: 'A1234AA',
-  potentialMatches: [
-    createPotentialMatch({ prisonNumber: 'A1234BB' }),
-    createPotentialMatch({ prisonNumber: 'A1234CC' }),
-  ],
-})
+const arrival = {
+  ...createArrival({
+    prisonNumber: 'A1234AA',
+    potentialMatches: [
+      createPotentialMatch({ prisonNumber: 'A1234BB' }),
+      createPotentialMatch({ prisonNumber: 'A1234CC' }),
+    ],
+  }),
+  matchType: MatchType.MULTIPLE_POTENTIAL_MATCHES,
+}
 
 let app: Express
 const expectedArrivalsService = createMockExpectedArrivalsService()

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/noMatchingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/noMatchingRecordsFoundController.test.ts
@@ -5,13 +5,17 @@ import { appWithAllRoutes } from '../../../__testutils/appSetup'
 import Role from '../../../../authentication/role'
 import { createArrival } from '../../../../data/__testutils/testObjects'
 import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
+import { MatchType } from '../../../../services/matchTypeDecorator'
 
 let app: Express
 const expectedArrivalsService = createMockExpectedArrivalsService()
 
-const arrival = createArrival({
-  potentialMatches: [],
-})
+const arrival = {
+  ...createArrival({
+    potentialMatches: [],
+  }),
+  matchType: MatchType.NO_MATCH,
+}
 
 beforeEach(() => {
   app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [Role.PRISON_RECEPTION] })

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.test.ts
@@ -7,14 +7,18 @@ import { expectSettingCookie } from '../../../__testutils/requestTestUtils'
 import { State } from '../state'
 import { createArrival, createPotentialMatch } from '../../../../data/__testutils/testObjects'
 import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
+import { MatchType } from '../../../../services/matchTypeDecorator'
 
 let app: Express
 const expectedArrivalsService = createMockExpectedArrivalsService()
 
-const arrival = createArrival({
-  prisonNumber: null,
-  potentialMatches: [createPotentialMatch({ prisonNumber: 'A1234AB' })],
-})
+const arrival = {
+  ...createArrival({
+    prisonNumber: null,
+    potentialMatches: [createPotentialMatch({ prisonNumber: 'A1234AB' })],
+  }),
+  matchType: MatchType.SINGLE_MATCH,
+}
 
 beforeEach(() => {
   app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [Role.PRISON_RECEPTION] })

--- a/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
@@ -8,13 +8,21 @@ import Role from '../../../../authentication/role'
 import config from '../../../../config'
 import { createArrival, createArrivalResponse, createPrisonerDetails } from '../../../../data/__testutils/testObjects'
 import { createMockExpectedArrivalsService } from '../../../../services/__testutils/mocks'
+import { MatchType } from '../../../../services/matchTypeDecorator'
 
 let app: Express
 const expectedArrivalsService = createMockExpectedArrivalsService()
 const raiseAnalyticsEvent = jest.fn() as RaiseAnalyticsEvent
 
 const courtReturn = createPrisonerDetails()
-const arrival = createArrival({ fromLocationType: LocationType.COURT, isCurrentPrisoner: true })
+
+const arrival = {
+  ...createArrival({
+    fromLocationType: LocationType.COURT,
+    isCurrentPrisoner: true,
+  }),
+  matchType: MatchType.SINGLE_MATCH,
+}
 const arrivalResponse = createArrivalResponse()
 
 beforeEach(() => {

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
@@ -1,4 +1,4 @@
-import type { Arrival } from 'welcome'
+import { Arrival, SexKeys } from 'welcome'
 import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
@@ -7,6 +7,7 @@ import Role from '../../../authentication/role'
 import { expectSettingCookie } from '../../__testutils/requestTestUtils'
 import { State } from './state'
 import { createMockExpectedArrivalsService } from '../../../services/__testutils/mocks'
+import { MatchType, WithMatchType } from '../../../services/matchTypeDecorator'
 
 let app: Express
 const expectedArrivalsService = createMockExpectedArrivalsService()
@@ -50,11 +51,12 @@ describe('GET /review-per-details', () => {
       firstName: 'James',
       lastName: 'Smyth',
       dateOfBirth: '1973-01-08',
-      gender: 'MALE',
+      gender: SexKeys.MALE,
       prisonNumber: 'A1234AB',
       pncNumber: '99/98644M',
       potentialMatches: [],
-    } as Arrival)
+      matchType: MatchType.SINGLE_MATCH,
+    } as WithMatchType<Arrival>)
 
     return request(app)
       .get('/prisoners/12345-67890/review-per-details')
@@ -75,11 +77,12 @@ describe('GET /review-per-details', () => {
       firstName: 'James',
       lastName: 'Smyth',
       dateOfBirth: '1973-01-08',
-      gender: 'MALE',
+      gender: SexKeys.MALE,
       prisonNumber: 'A1234AB',
       pncNumber: '99/98644M',
       potentialMatches: [],
-    } as Arrival)
+      matchType: MatchType.SINGLE_MATCH,
+    } as WithMatchType<Arrival>)
 
     return request(app)
       .get('/prisoners/12345-67890/review-per-details')

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
@@ -8,6 +8,7 @@ import config from '../../../../../config'
 import { expectSettingCookie } from '../../../../__testutils/requestTestUtils'
 import { State } from '../../state'
 import { createMockExpectedArrivalsService } from '../../../../../services/__testutils/mocks'
+import { MatchType, WithMatchType } from '../../../../../services/matchTypeDecorator'
 
 let app: Express
 const expectedArrivalsService = createMockExpectedArrivalsService()
@@ -87,7 +88,8 @@ describe('GET /search-for-existing-record', () => {
       prisonNumber: 'A1234AB',
       pncNumber: '99/98644M',
       potentialMatches: [],
-    } as Arrival)
+      matchType: MatchType.NO_MATCH,
+    } as WithMatchType<Arrival>)
 
     return request(app)
       .get('/prisoners/12345-67890/search-for-existing-record')
@@ -105,7 +107,8 @@ describe('GET /search-for-existing-record', () => {
       prisonNumber: 'A1234AB',
       pncNumber: '99/98644M',
       potentialMatches: [],
-    } as Arrival)
+      matchType: MatchType.NO_MATCH,
+    } as WithMatchType<Arrival>)
 
     return request(app)
       .get('/prisoners/12345-67890/search-for-existing-record')

--- a/server/routes/recentArrivals/recentArrivalsController.test.ts
+++ b/server/routes/recentArrivals/recentArrivalsController.test.ts
@@ -5,7 +5,7 @@ import * as cheerio from 'cheerio'
 import { appWithAllRoutes, user } from '../__testutils/appSetup'
 import Role from '../../authentication/role'
 
-import { createRecentArrival } from '../../data/__testutils/testObjects'
+import { createRecentArrival, withBodyScanInfo } from '../../data/__testutils/testObjects'
 import { expectSettingCookie } from '../__testutils/requestTestUtils'
 import { State } from './state'
 import { createMockExpectedArrivalsService } from '../../services/__testutils/mocks'
@@ -18,8 +18,8 @@ const oneDayAgo = moment().subtract(1, 'days').startOf('day')
 const twoDaysAgo = moment().subtract(2, 'days').startOf('day')
 
 const recentArrivals = new Map([
-  [today, [createRecentArrival({ movementDateTime: moment().format() })]],
-  [oneDayAgo, [createRecentArrival({ movementDateTime: moment().subtract(1, 'days').format() })]],
+  [today, [withBodyScanInfo(createRecentArrival({ movementDateTime: moment().format() }))]],
+  [oneDayAgo, [withBodyScanInfo(createRecentArrival({ movementDateTime: moment().subtract(1, 'days').format() }))]],
   [twoDaysAgo, []],
 ])
 

--- a/server/services/__testutils/mocks.ts
+++ b/server/services/__testutils/mocks.ts
@@ -7,12 +7,13 @@ import {
   TemporaryAbsencesService,
   UserService,
   NotificationService,
+  MatchTypeDecorator,
 } from '..'
 
 jest.mock('..')
 
 export const createMockExpectedArrivalsService = () =>
-  new ExpectedArrivalsService(null, null, null, null) as jest.Mocked<ExpectedArrivalsService>
+  new ExpectedArrivalsService(null, null, null, null, null) as jest.Mocked<ExpectedArrivalsService>
 
 export const createMockImprisonmentStatusesService = () =>
   new ImprisonmentStatusesService(null, null) as jest.Mocked<ImprisonmentStatusesService>
@@ -23,6 +24,8 @@ export const createMockTransfersService = () => new TransfersService(null, null)
 
 export const createMockBodyScanInfoDecorator = () =>
   new BodyScanInfoDecorator(null, null) as jest.Mocked<BodyScanInfoDecorator>
+
+export const createMockMatchTypeDecorator = () => new MatchTypeDecorator() as jest.Mocked<MatchTypeDecorator>
 
 export const createMockTemporaryAbsencesService = () =>
   new TemporaryAbsencesService(null, null, null) as jest.Mocked<TemporaryAbsencesService>

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -8,18 +8,22 @@ import PrisonService from './prisonService'
 import NotificationService from './notificationService'
 import { raiseAnalyticsEvent, type RaiseAnalyticsEvent } from './raiseAnalyticsEvent'
 import { BodyScanInfoDecorator } from './bodyScanInfoDecorator'
+import { MatchTypeDecorator } from './matchTypeDecorator'
 
 export const services = () => {
   const { hmppsAuthClient, welcomeClientBuilder, bodyScanClientBuilder, notifyClient } = dataAccess()
 
   const bodyScanInfoDecorator = new BodyScanInfoDecorator(hmppsAuthClient, bodyScanClientBuilder)
+  const matchTypeDecorator = new MatchTypeDecorator()
+
   const userService = new UserService(hmppsAuthClient, welcomeClientBuilder)
   const notificationService = new NotificationService(notifyClient)
   const expectedArrivalsService = new ExpectedArrivalsService(
     hmppsAuthClient,
     welcomeClientBuilder,
     raiseAnalyticsEvent,
-    bodyScanInfoDecorator
+    bodyScanInfoDecorator,
+    matchTypeDecorator
   )
   const temporaryAbsencesService = new TemporaryAbsencesService(
     hmppsAuthClient,
@@ -47,6 +51,7 @@ export type Services = ReturnType<typeof services>
 
 export {
   BodyScanInfoDecorator,
+  MatchTypeDecorator,
   UserService,
   NotificationService,
   ExpectedArrivalsService,

--- a/server/services/matchTypeDecorator.test.ts
+++ b/server/services/matchTypeDecorator.test.ts
@@ -1,0 +1,53 @@
+import { PotentialMatch } from 'welcome'
+import { ArrivalInfo, MatchType, MatchTypeDecorator } from './matchTypeDecorator'
+
+describe('MatchTypeDecorator', () => {
+  const service = new MatchTypeDecorator()
+
+  const potentialMatch = {} as PotentialMatch
+  const arrival = ({ prisonNumber, pncNumber, potentialMatches }: ArrivalInfo) => ({
+    prisonNumber,
+    pncNumber,
+    potentialMatches,
+  })
+
+  describe('getMatchType', () => {
+    test('insufficient info', async () => {
+      const result = service.getMatchType(arrival({}))
+      expect(result).toBe(MatchType.INSUFFICIENT_INFO)
+    })
+
+    test('no match - undefined matches', async () => {
+      const result = service.getMatchType(arrival({ prisonNumber: 'A1234AA', pncNumber: '01/12345A' }))
+      expect(result).toBe(MatchType.NO_MATCH)
+    })
+
+    test('no match - empty matches', async () => {
+      const result = service.getMatchType(
+        arrival({ prisonNumber: 'A1234AA', pncNumber: '01/12345A', potentialMatches: [] })
+      )
+      expect(result).toBe(MatchType.NO_MATCH)
+    })
+
+    test('single match', async () => {
+      const result = service.getMatchType(
+        arrival({ prisonNumber: 'A1234AA', pncNumber: '01/12345A', potentialMatches: [potentialMatch] })
+      )
+      expect(result).toBe(MatchType.SINGLE_MATCH)
+    })
+
+    test('mutiple potential matches', async () => {
+      const result = service.getMatchType(
+        arrival({ prisonNumber: 'A1234AA', pncNumber: '01/12345A', potentialMatches: [potentialMatch, potentialMatch] })
+      )
+      expect(result).toBe(MatchType.MULTIPLE_POTENTIAL_MATCHES)
+    })
+  })
+
+  describe('decorate', () => {
+    test('insufficient info', async () => {
+      const [result] = service.decorate([arrival({})])
+      expect(result.matchType).toBe(MatchType.INSUFFICIENT_INFO)
+    })
+  })
+})

--- a/server/services/matchTypeDecorator.ts
+++ b/server/services/matchTypeDecorator.ts
@@ -1,0 +1,36 @@
+import { PotentialMatch } from 'welcome'
+
+export const enum MatchType {
+  INSUFFICIENT_INFO = 'INSUFFICIENT_INFO',
+  SINGLE_MATCH = 'SINGLE_MATCH',
+  NO_MATCH = 'NO_MATCH',
+  MULTIPLE_POTENTIAL_MATCHES = 'MULTIPLE_POTENTIAL_MATCHES',
+}
+
+export type ArrivalInfo = { prisonNumber?: string; pncNumber?: string; potentialMatches?: PotentialMatch[] }
+
+export type WithMatchType<T extends ArrivalInfo> = T & { matchType: MatchType }
+
+export class MatchTypeDecorator {
+  public decorate<T extends ArrivalInfo>(items: T[]): WithMatchType<T>[] {
+    return items.map(item => this.decorateSingle(item))
+  }
+
+  public decorateSingle<T extends ArrivalInfo>(item: T): WithMatchType<T> {
+    return { ...item, matchType: this.getMatchType(item) }
+  }
+
+  public getMatchType<T extends ArrivalInfo>(item: T): MatchType {
+    if (!item.prisonNumber && !item.pncNumber) {
+      return MatchType.INSUFFICIENT_INFO
+    }
+    switch (item.potentialMatches?.length || 0) {
+      case 0:
+        return MatchType.NO_MATCH
+      case 1:
+        return MatchType.SINGLE_MATCH
+      default:
+        return MatchType.MULTIPLE_POTENTIAL_MATCHES
+    }
+  }
+}


### PR DESCRIPTION
Now decorating incoming arrivals with information about the type of match we have been able to work out for an arrival.
There are 4 possible options, 3 self evident: 
```
  SINGLE_MATCH
  NO_MATCH
  MULTIPLE_POTENTIAL_MATCHES
```

And a special option of `INSUFFICIENT_INFO` for when we haven't been provided a PNC or prisoner number. In this case we don't entirely trust a name and Dob match.

This additional data, slightly simplifies the routing logic when working out how to process a prisoner. We will also use this info to work out whether to show a photo.
We currently always show the photo associated with the first potential match which can be a bit confusing for multiple matches and when we have insufficient data 