### PR TITLE
DCS-1852 Move dotenv to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "cookie-session": "^2.0.0",
         "csurf": "^1.11.0",
         "csv-parse": "^5.3.0",
-        "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "express-session": "^1.17.3",
         "googleapis": "^105.0.0",
@@ -73,6 +72,7 @@
         "concurrently": "^7.3.0",
         "cypress": "^10.3.1",
         "cypress-multi-reporters": "^1.6.1",
+        "dotenv": "^16.0.2",
         "eslint": "^8.20.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
@@ -5635,9 +5635,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -17389,9 +17390,10 @@
       }
     },
     "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "dev": true
     },
     "dtrace-provider": {
       "version": "0.8.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "compile-sass": "sass --quiet-deps --no-source-map --load-path=. --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend ./assets/sass/application.sass:./assets/stylesheets/application.css ./assets/sass/application-ie8.sass:./assets/stylesheets/application-ie8.css --style compressed",
     "watch-ts": "tsc -w",
     "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
-    "watch-node": "DEBUG=gov-starter-server* nodemon --watch dist/ dist/server.js | bunyan -o short",
+    "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ dist/server.js | bunyan -o short",
     "watch-sass": "npm run compile-sass -- --watch",
     "build": "npm run compile-sass && tsc && npm run copy-views",
     "start": "node $NODE_OPTIONS dist/server.js | bunyan -o short",
@@ -37,7 +37,6 @@
     "globals": {
       "ts-jest": {
         "isolatedModules": true
-
       }
     },
     "collectCoverageFrom": [
@@ -105,7 +104,6 @@
     "cookie-session": "^2.0.0",
     "csurf": "^1.11.0",
     "csv-parse": "^5.3.0",
-    "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "express-session": "^1.17.3",
     "googleapis": "^105.0.0",
@@ -155,6 +153,7 @@
     "concurrently": "^7.3.0",
     "cypress": "^10.3.1",
     "cypress-multi-reporters": "^1.6.1",
+    "dotenv": "^16.0.2",
     "eslint": "^8.20.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.5.0",

--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,6 @@
+// Require app insights before anything else to allow for instrumentation of bunyan and express
+import 'applicationinsights'
+
 import app from './server/index'
 import logger from './logger'
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config'
 import os from 'os'
 
 const production = process.env.NODE_ENV === 'production'

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,3 @@
-// Require app insights before anything else to allow for instrumentation of bunyan and express
-import './utils/azureAppInsights'
-
 import createApp from './app'
 import { services as wpipServicesBuilder } from './services'
 import { services as bodyScanServicesBuilder } from './bodyscan/services'

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config'
 import { Contracts, defaultClient, DistributedTracingModes, setup, TelemetryClient } from 'applicationinsights'
 import { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
 import applicationVersion from '../applicationVersion'


### PR DESCRIPTION
Moving dotenv to dev dependencies. This removes some code that is only relevant for local development. This code was a bit tricky as it required running at a specific time in the application lifecycle.

There was a weird bug where the app insight initialise() would fail if the env vars weren't present before the app insights import.

This now means the application runs similar locally to how it would run in docker or kubernetes.

Also moving the app insights import so it's very obviously the first thing that happens when the app starts.