### PR TITLE
DCS-1857 redirect court flow to feature not available as short term fix for redirect to court flow

### DIFF
--- a/server/routes/bookedtoday/arrivals/confirmArrival/startConfirmationController.test.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/startConfirmationController.test.ts
@@ -47,14 +47,14 @@ describe('/start-confirmation', () => {
           .expect('Location', '/prisoners/12345-67890/sex')
       })
 
-      it('should redirect to court return flow when FROM_COURT', () => {
+      it('should redirect to feature not available flow when FROM_COURT', () => {
         expectedArrivalsService.getPrisonerDetails.mockResolvedValue(
           createPrisonerDetails({ arrivalType: 'FROM_COURT' })
         )
         return request(app)
           .get('/prisoners/12345-67890/start-confirmation')
           .expect(302)
-          .expect('Location', '/prisoners/12345-67890/check-court-return')
+          .expect('Location', '/feature-not-available')
       })
 
       it('should redirect to temporary absence flow when FROM_TEMPORARY_ABSENCE', () => {

--- a/server/routes/bookedtoday/arrivals/confirmArrival/startConfirmationController.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/startConfirmationController.ts
@@ -8,7 +8,6 @@ const urls = {
   sex: path('/prisoners/:id/sex'),
   transfers: path('/prisoners/:prisonNumber/check-transfer'),
   temporaryAbsence: path('/prisoners/:prisonNumber/check-temporary-absence'),
-  courtReturn: path('/prisoners/:id/check-court-return'),
   featureNotAvailable: path('/feature-not-available'),
 }
 
@@ -30,7 +29,7 @@ export default class StartConfirmationController {
         return urls.sex({ id })
 
       case 'FROM_COURT':
-        return urls.courtReturn({ id })
+        return urls.featureNotAvailable({})
 
       case 'FROM_TEMPORARY_ABSENCE':
         return urls.temporaryAbsence({ prisonNumber })


### PR DESCRIPTION
- When searching for an unexpected arrival a user may find a single matched record
- This record could marked as out on a court visit
- When the user tries to continue against this record, rather than route to the confirm arrival steps the service recognises the record as coming back from court and routes the user to the court return booking flow
- This route results in failure 

We have another ticket to properly address the problem described above. This is a short term fix to redirect court returns to feature-not-available page after we “resolve arrival type”, see [image](https://app.diagrams.net/?title=rejig-resolution&client=1#G1WnwY4nO0jY4owlsXXSf_AAXt4H3zF-YI) 

The existing court return flow, after you select a prisoner from the choose prisoner page still exists.