### PR TITLE
DCS-1859 check for search details cookie on review details page

### DIFF
--- a/server/routes/__testutils/requestTestUtils.ts
+++ b/server/routes/__testutils/requestTestUtils.ts
@@ -74,8 +74,9 @@ export const expectSettingCookie = <T>(
   res: superAgent.Response,
   stateOperations: StateOperations<T>
 ): jest.JestMatchers<T> => {
-  const [cookie] = res.header['set-cookie']
-  const [, name, value] = cookie.match(/^(.*?)=(.*?);/)
+  const cookies = res.header['set-cookie']
+  const matchedCookie = cookies.find((c: string) => c.includes(stateOperations.cookieName))
+  const [, name, value] = matchedCookie.match(/^(.*?)=(.*?);/)
 
   expect(name).toBe(stateOperations.cookieName)
 

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
@@ -72,7 +72,7 @@ describe('GET /review-per-details', () => {
       })
   })
 
-  it('should render page when no initial new arrival cookie state', () => {
+  it('should render page when no initial search details cookie or new arrival cookie state', () => {
     expectedArrivalsService.getArrival.mockResolvedValue({
       firstName: 'James',
       lastName: 'Smyth',
@@ -93,7 +93,7 @@ describe('GET /review-per-details', () => {
       })
   })
 
-  it('should render page with initial new arrival cookie state', () => {
+  it('should render page with initial new arrival cookie state if present and search details cookie absent', () => {
     stubCookie(State.newArrival, {
       firstName: 'James',
       lastName: 'Smyth',
@@ -109,6 +109,35 @@ describe('GET /review-per-details', () => {
       .expect(res => {
         const $ = cheerio.load(res.text)
         expect($('h1').text()).toContain('Review personal details')
+        expect($('.data-qa-name').text()).toContain('James Smyth')
+      })
+  })
+
+  it('should render page with search details cookie state if present', () => {
+    stubCookie(State.newArrival, {
+      firstName: 'James',
+      lastName: 'Smyth',
+      dateOfBirth: '1973-01-08',
+      sex: 'MALE',
+      prisonNumber: 'A1234AB',
+      pncNumber: '99/98644M',
+      expected: true,
+    })
+
+    stubCookie(State.searchDetails, {
+      firstName: 'Jim',
+      lastName: 'Smyth',
+      dateOfBirth: '1973-01-08',
+      pncNumber: '99/98644M',
+      prisonNumber: 'A1234AB',
+    })
+
+    return request(app)
+      .get('/prisoners/12345-67890/review-per-details')
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('h1').text()).toContain('Review personal details')
+        expect($('.data-qa-name').text()).toContain('Jim Smyth')
       })
   })
 })

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.ts
@@ -35,7 +35,7 @@ export default class ReviewDetailsController {
     return async (req, res, next) => {
       const { id } = req.params
 
-      const data = State.newArrival.get(req) || (await this.loadData(id, req, res))
+      const data = State.searchDetails.get(req) || State.newArrival.get(req) || (await this.loadData(id, req, res))
 
       res.render('pages/bookedtoday/arrivals/reviewDetails.njk', {
         data: { ...data, id },

--- a/server/routes/bookedtoday/choosePrisonerController.test.ts
+++ b/server/routes/bookedtoday/choosePrisonerController.test.ts
@@ -2,7 +2,7 @@ import type { Arrival } from 'welcome'
 import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
-import { user, appWithAllRoutes } from '../__testutils/appSetup'
+import { user, appWithAllRoutes, stubCookie } from '../__testutils/appSetup'
 import { expectSettingCookie } from '../__testutils/requestTestUtils'
 import config from '../../config'
 import { State } from './arrivals/state'
@@ -89,8 +89,16 @@ describe('GET /confirm-arrival/choose-prisoner/:id', () => {
       matchType,
     } as WithMatchType<Arrival>)
 
+  stubCookie(State.searchDetails, {
+    firstName: 'James',
+    lastName: 'Smyth',
+    dateOfBirth: '1973-01-08',
+    pncNumber: '99/98644M',
+    prisonNumber: 'A1234AB',
+  })
+
   describe('from court', () => {
-    it('should clear cookie', () => {
+    it('should clear both new arrival and search details cookies', () => {
       expectedArrivalsService.getArrival.mockResolvedValue(
         arrival({
           matchType: MatchType.SINGLE_MATCH,
@@ -100,6 +108,7 @@ describe('GET /confirm-arrival/choose-prisoner/:id', () => {
         .get('/confirm-arrival/choose-prisoner/aaa-111-222')
         .expect(res => {
           expectSettingCookie(res, State.newArrival).toBeUndefined()
+          expectSettingCookie(res, State.searchDetails).toBeUndefined()
         })
     })
 

--- a/server/routes/bookedtoday/choosePrisonerController.ts
+++ b/server/routes/bookedtoday/choosePrisonerController.ts
@@ -19,6 +19,7 @@ export default class ChoosePrisonerController {
   public redirectToConfirm(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
+      State.searchDetails.clear(res)
       State.newArrival.clear(res)
       const arrival = await this.expectedArrivalsService.getArrival(id)
 


### PR DESCRIPTION
If there is a record with no identifiers, and a user makes changes on the search for existing page (e.g. adds an identifier for an existing prisoner and changes the DoB). When they click search they should see the single match page with the search details on the left and the found record on the right.

If they choose to create a new record then they will see the details of the original arrival (with original DoB) on the review details page rather than the searched DoB.

This change will prioritise looking at the search details before loading the current arrival so that a user will end up seeing these on the review details page if present. 