### PR TITLE
DCS-1877 update get temporary absence endpoint following endpoint update for fix in backend

### DIFF
--- a/integration_tests/mockApis/welcome.ts
+++ b/integration_tests/mockApis/welcome.ts
@@ -180,7 +180,6 @@ export default {
   },
 
   stubTemporaryAbsence: ({
-    activeCaseLoadId,
     prisonNumber,
     temporaryAbsence,
   }: {
@@ -191,7 +190,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/welcome/prison/${activeCaseLoadId}/temporary-absences/${prisonNumber}`,
+        urlPattern: `/welcome/temporary-absences/${prisonNumber}`,
       },
       response: {
         status: 200,

--- a/server/data/welcomeClient.test.ts
+++ b/server/data/welcomeClient.test.ts
@@ -166,16 +166,15 @@ describe('welcomeClient', () => {
   })
 
   describe('getTemporaryAbsence', () => {
-    const activeCaseLoadId = 'MDI'
     const prisonNumber = 'A1234AB'
     const temporaryAbsence = createTemporaryAbsence()
     it('should return single a transfer from api', async () => {
       fakeWelcomeApi
-        .get(`/prison/${activeCaseLoadId}/temporary-absences/${prisonNumber}`)
+        .get(`/temporary-absences/${prisonNumber}`)
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, temporaryAbsence)
 
-      const output = await welcomeClient.getTemporaryAbsence(activeCaseLoadId, prisonNumber)
+      const output = await welcomeClient.getTemporaryAbsence(prisonNumber)
       expect(output).toEqual(temporaryAbsence)
     })
   })

--- a/server/data/welcomeClient.ts
+++ b/server/data/welcomeClient.ts
@@ -113,10 +113,10 @@ export default class WelcomeClient {
     }) as Promise<TemporaryAbsence[]>
   }
 
-  async getTemporaryAbsence(agencyId: string, prisonNumber: string): Promise<TemporaryAbsence> {
-    logger.info(`welcomeApi: getTemporaryAbsence(${agencyId} ${prisonNumber})`)
+  async getTemporaryAbsence(prisonNumber: string): Promise<TemporaryAbsence> {
+    logger.info(`welcomeApi: getTemporaryAbsence(${prisonNumber})`)
     return this.restClient.get({
-      path: `/prison/${agencyId}/temporary-absences/${prisonNumber}`,
+      path: `/temporary-absences/${prisonNumber}`,
     }) as Promise<TemporaryAbsence>
   }
 

--- a/server/routes/temporaryabsences/checkTemporaryAbsenceController.test.ts
+++ b/server/routes/temporaryabsences/checkTemporaryAbsenceController.test.ts
@@ -41,7 +41,7 @@ describe('GET checkTemporaryAbsence', () => {
       .get('/prisoners/A1234AA/check-temporary-absence')
       .expect('Content-Type', /text\/html/)
       .expect(() => {
-        expect(temporaryAbsencesService.getTemporaryAbsence).toHaveBeenCalledWith('MDI', 'A1234AA')
+        expect(temporaryAbsencesService.getTemporaryAbsence).toHaveBeenCalledWith('A1234AA')
       })
   })
 

--- a/server/routes/temporaryabsences/checkTemporaryAbsenceController.ts
+++ b/server/routes/temporaryabsences/checkTemporaryAbsenceController.ts
@@ -9,10 +9,9 @@ export default class CheckTemporaryAbsenceController {
 
   public checkTemporaryAbsence(): RequestHandler {
     return async (req, res) => {
-      const { activeCaseLoadId } = res.locals.user
       const { arrivalId } = req.query
       const { prisonNumber } = req.params
-      const data = await this.temporaryAbsencesService.getTemporaryAbsence(activeCaseLoadId, prisonNumber)
+      const data = await this.temporaryAbsencesService.getTemporaryAbsence(prisonNumber)
       return res.render('pages/temporaryabsences/checkTemporaryAbsence.njk', { data, arrivalId })
     }
   }
@@ -23,7 +22,7 @@ export default class CheckTemporaryAbsenceController {
       const { username } = req.user
       const { arrivalId } = req.body
       const { activeCaseLoadId } = res.locals.user
-      const data = await this.temporaryAbsencesService.getTemporaryAbsence(activeCaseLoadId, prisonNumber)
+      const data = await this.temporaryAbsencesService.getTemporaryAbsence(prisonNumber)
 
       const arrivalResponse = await this.temporaryAbsencesService.confirmTemporaryAbsence(
         username,

--- a/server/services/temporaryAbsencesService.test.ts
+++ b/server/services/temporaryAbsencesService.test.ts
@@ -62,16 +62,16 @@ describe('Temporary absences service', () => {
       welcomeClient.getTemporaryAbsence.mockResolvedValue(temporaryAbsence)
     })
     it('Calls upstream service correctly', async () => {
-      await service.getTemporaryAbsence('MDI', 'G0013AB')
+      await service.getTemporaryAbsence('G0013AB')
 
       expect(WelcomeClientFactory).toBeCalledWith(token)
-      expect(welcomeClient.getTemporaryAbsence).toBeCalledWith('MDI', 'G0013AB')
+      expect(welcomeClient.getTemporaryAbsence).toBeCalledWith('G0013AB')
     })
 
     it('Should return correct data', async () => {
       welcomeClient.getTemporaryAbsence.mockResolvedValue(temporaryAbsence)
 
-      const result = await service.getTemporaryAbsence('MDI', 'G0013AB')
+      const result = await service.getTemporaryAbsence('G0013AB')
 
       expect(result).toStrictEqual(temporaryAbsence)
     })

--- a/server/services/temporaryAbsencesService.ts
+++ b/server/services/temporaryAbsencesService.ts
@@ -17,9 +17,9 @@ export default class TemporaryAbsencesService {
     return temporaryAbsences.sort(compareByFullName)
   }
 
-  public async getTemporaryAbsence(agencyId: string, prisonNumber: string): Promise<TemporaryAbsence> {
+  public async getTemporaryAbsence(prisonNumber: string): Promise<TemporaryAbsence> {
     const token = await this.hmppsAuthClient.getSystemClientToken()
-    return this.welcomeClientFactory(token).getTemporaryAbsence(agencyId, prisonNumber)
+    return this.welcomeClientFactory(token).getTemporaryAbsence(prisonNumber)
   }
 
   public async confirmTemporaryAbsence(


### PR DESCRIPTION
Update to the getTemporaryAbsence endpoint in the frontend following update of this endpoint in the backend. 

This was done so that the service does not blow up when a user redirects an arrival to a temporary absence from another prison (which can occur if they search for an arrival with an identifier of a temporary absence from another prison).

Previously the endpoint would not be able to retrieve this temporary absence (as it searched using the agencyId of the user's current active caseload rather than that of the temporary absence) and cause the service to fail on the check temporary absence page. 

Now a user can redirect to this page and view the temporary absence information for temporary absences from another prison, but if they try to confirm the backend will throw an exception and redirect them to the feature not available page (which asks them to complete the process in NOMIS. 