### PR TITLE
DCS-1983 create new record bug fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'sudo npm install -g npm@latest'
+          command: 'sudo npm install -g npm@9.2.0'
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
@@ -72,6 +72,25 @@ describe('GET /review-per-details', () => {
       })
   })
 
+  it('should update new arrival cookie from search details cookie when search details present and new arrival undefined', () => {
+    stubCookie(State.searchDetails, {
+      firstName: 'James',
+      lastName: 'Smyth',
+      dateOfBirth: '1973-01-08',
+    })
+
+    return request(app)
+      .get('/prisoners/12345-67890/review-per-details')
+      .expect(res => {
+        expectSettingCookie(res, State.newArrival).toStrictEqual({
+          firstName: 'James',
+          lastName: 'Smyth',
+          dateOfBirth: '1973-01-08',
+          expected: 'true',
+        })
+      })
+  })
+
   it('should render page when no initial search details cookie or new arrival cookie state', () => {
     expectedArrivalsService.getArrival.mockResolvedValue({
       firstName: 'James',

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.ts
@@ -37,6 +37,17 @@ export default class ReviewDetailsController {
 
       const data = State.searchDetails.get(req) || State.newArrival.get(req) || (await this.loadData(id, req, res))
 
+      if (State.searchDetails.isStatePresent(req) && !State.newArrival.isStatePresent(req)) {
+        const updateNewArrival = {
+          firstName: convertToTitleCase(data.firstName),
+          lastName: convertToTitleCase(data.lastName),
+          dateOfBirth: data.dateOfBirth,
+          expected: true,
+        }
+
+        State.newArrival.set(res, updateNewArrival)
+      }
+
       res.render('pages/bookedtoday/arrivals/reviewDetails.njk', {
         data: { ...data, id },
       })


### PR DESCRIPTION
Bug fix to populate new arrival cookie state from search details in search for existing journey. When a user cannot find an arrival match and clicks the create a new record link on the single match or multiple match page: 
<img width="888" alt="Screenshot 2023-01-16 at 18 35 07" src="https://user-images.githubusercontent.com/48809053/212746117-83f6e258-0ff2-4748-a539-895beab4aa94.png">

This link redirects to `/review-per-details/new` which clears out pre-existing new arrival state, however this does need to be repopulated from search details as when a user continues on from the review page the prison number is deconstructed from the new arrival state as the `start-confirmation` controller redirects to the relevant new arrival confirmation journey. 