### PR TITLE
DCS-2008 add over body scan limit warning to pre arrival summery page

### DIFF
--- a/assets/sass/components/_compliance-panel.scss
+++ b/assets/sass/components/_compliance-panel.scss
@@ -7,3 +7,7 @@
       color: inherit;
     }
 }
+
+.compliance-panel--red {
+  background: govuk-colour("red");
+}

--- a/server/views/pages/bookedtoday/summaryWithRecord.njk
+++ b/server/views/pages/bookedtoday/summaryWithRecord.njk
@@ -73,7 +73,13 @@
                             }
                         ]
                     }) }}
-                    {% if summary.bodyScanStatus === 'CLOSE_TO_LIMIT'  %}
+                    {% if summary.bodyScanStatus === 'DO_NOT_SCAN' %}
+                        <div class="compliance-panel compliance-panel--red">
+                            <p class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold">
+                                Do not scan – annual body scan limit reached
+                            </p>
+                        </div>
+                    {% elif summary.bodyScanStatus === 'CLOSE_TO_LIMIT'  %}
                         <div class="compliance-panel">
                             <p class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold">
                                 {{ arrival.firstName }} {{ arrival.lastName }} can only be scanned {{ summary.numberOfBodyScansRemaining }} more times this year


### PR DESCRIPTION
Added red over body scan limit warning to pre arrival summary page as below. This only displays when a person has reached 116+ body scans:

<img width="608" alt="Screenshot 2023-02-09 at 12 11 46" src="https://user-images.githubusercontent.com/48809053/217810488-513e8c51-b5c0-4b37-af6a-0709890f1cd5.png">
