### PR TITLE
DCS-2009 add over body scan limit warning to post arrival summary page

### DIFF
--- a/server/views/pages/recentArrivals/recentArrivalsSummary.njk
+++ b/server/views/pages/recentArrivals/recentArrivalsSummary.njk
@@ -70,7 +70,13 @@
                             }
                         ]
                     }) }}
-                    {% if arrival.bodyScanStatus === 'CLOSE_TO_LIMIT'  %}
+                    {% if arrival.bodyScanStatus === 'DO_NOT_SCAN' %}
+                        <div class="compliance-panel compliance-panel--red">
+                            <p class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold">
+                                Do not scan – annual body scan limit reached
+                            </p>
+                        </div>
+                    {% elif arrival.bodyScanStatus === 'CLOSE_TO_LIMIT'  %}
                         <div class="compliance-panel">
                             <p class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold">
                                 {{ arrival.firstName }} {{ arrival.lastName }} can only be scanned {{ arrival.numberOfBodyScansRemaining }} more times this year


### PR DESCRIPTION
Added red over body scan limit warning to post arrival summary page as below. This only displays when a person has reached 116+ body scans:
<img width="620" alt="Screenshot 2023-02-09 at 13 16 00" src="https://user-images.githubusercontent.com/48809053/217823170-bbcbac09-da8a-4e84-bcb7-2b10251d75b1.png">