### PR TITLE
DCS-1927 add link pointing to prisoner profile on dps

### DIFF
--- a/server/authentication/role.ts
+++ b/server/authentication/role.ts
@@ -1,5 +1,6 @@
 const enum Role {
   PRISON_RECEPTION = 'ROLE_PRISON_RECEPTION',
+  ROLE_INACTIVE_BOOKINGS = 'ROLE_INACTIVE_BOOKINGS',
 }
 
 export default Role

--- a/server/routes/bookedtoday/index.ts
+++ b/server/routes/bookedtoday/index.ts
@@ -6,7 +6,6 @@ import transferRoutes from './transfers'
 import arrivalRoutes from './arrivals'
 import unexpectedArrivalsRoutes from './unexpectedArrivals'
 import Routes from '../../utils/routeBuilder'
-import Role from '../../authentication/role'
 import SummaryWithRecordController from './summaryWithRecordController'
 import SummaryMoveOnlyController from './summaryMoveOnlyController'
 
@@ -19,7 +18,6 @@ export default function routes(services: Services): Router {
     .get('/confirm-arrival/choose-prisoner', choosePrisonerController.view())
     .get('/confirm-arrival/choose-prisoner/:id', choosePrisonerController.redirectToConfirm())
 
-    .forRole(Role.PRISON_RECEPTION)
     .get('/prisoners/:id/summary-with-record', summaryWithRecordController.view())
     .get('/prisoners/:id/summary-move-only', summaryMoveOnlyController.view())
 

--- a/server/routes/bookedtoday/summaryWithRecordController.test.ts
+++ b/server/routes/bookedtoday/summaryWithRecordController.test.ts
@@ -21,7 +21,7 @@ const arrivalAndSummaryDetails = {
 }
 
 beforeEach(() => {
-  app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [Role.PRISON_RECEPTION] })
+  app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [] })
 })
 
 afterEach(() => {
@@ -91,6 +91,55 @@ describe('GET /prisoner/:id/summary-with-record', () => {
         .expect(res => {
           const $ = cheerio.load(res.text)
           expect($('span.govuk-caption-l').text().trim()).toStrictEqual('Prison number: A1234AB | PNC: 01/98644M')
+        })
+    })
+  })
+
+  describe('DPS prisoner profile button', () => {
+    it('should be displayed', () => {
+      app = appWithAllRoutes({
+        services: { expectedArrivalsService },
+        roles: [Role.PRISON_RECEPTION, Role.ROLE_INACTIVE_BOOKINGS],
+      })
+
+      return request(app)
+        .get('/prisoners/1111-1111-1111-1111/summary-with-record')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-qa=dps-link]').length).toBe(1)
+        })
+    })
+    it('should not be displayed without Prison Reception role', () => {
+      app = appWithAllRoutes({
+        services: { expectedArrivalsService },
+        roles: [Role.ROLE_INACTIVE_BOOKINGS],
+      })
+
+      return request(app)
+        .get('/prisoners/1111-1111-1111-1111/summary-with-record')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-qa=dps-link]').length).toBe(0)
+        })
+    })
+
+    it('should not be present without Released Prisoner role', () => {
+      app = appWithAllRoutes({
+        services: { expectedArrivalsService },
+        roles: [Role.PRISON_RECEPTION],
+      })
+
+      return request(app)
+        .get('/prisoners/1111-1111-1111-1111/summary-with-record')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-qa=dps-link]').length).toBe(0)
         })
     })
   })

--- a/server/routes/bookedtoday/summaryWithRecordController.ts
+++ b/server/routes/bookedtoday/summaryWithRecordController.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from 'express'
 import { ExpectedArrivalsService } from '../../services'
+import Role from '../../authentication/role'
 
 export default class SummaryWithRecordController {
   public constructor(private readonly expectedArrivalsService: ExpectedArrivalsService) {}
@@ -7,8 +8,10 @@ export default class SummaryWithRecordController {
   public view(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
+      const { roles } = res.locals.user
+      const enableDpsLink = roles.includes(Role.PRISON_RECEPTION) && roles.includes(Role.ROLE_INACTIVE_BOOKINGS)
       const data = await this.expectedArrivalsService.getArrivalAndSummaryDetails(id)
-      return res.render('pages/bookedtoday/summaryWithRecord.njk', data)
+      return res.render('pages/bookedtoday/summaryWithRecord.njk', { ...data, enableDpsLink })
     }
   }
 }

--- a/server/views/pages/bookedtoday/summaryWithRecord.njk
+++ b/server/views/pages/bookedtoday/summaryWithRecord.njk
@@ -24,6 +24,14 @@
                     <h1 class="govuk-heading-l">{{ arrival.lastName }}, {{ arrival.firstName }}</h1>
                 </div>
                 <div class="govuk-grid-column-one-half">
+                    {% if(enableDpsLink) %}
+                        {{ govukButton({
+                            text: "View full prisoner profile",
+                            href: dpsUrl + "/prisoner/" + arrival.prisonNumber,
+                            attributes: {'data-qa':'dps-link'},
+                            classes: "govuk-button--secondary moj-button-menu__item govuk-!-margin-left-3 govuk-!-margin-right-0 float-right"
+                        }) }}
+                    {% endif %}
                     {{ govukButton({
                         text: "Confirm arrival",
                         href: "/confirm-arrival/choose-prisoner/" + arrival.id,

--- a/server/views/pages/bookedtoday/summaryWithRecord.njk
+++ b/server/views/pages/bookedtoday/summaryWithRecord.njk
@@ -27,7 +27,7 @@
                     {% if(enableDpsLink) %}
                         {{ govukButton({
                             text: "View full prisoner profile",
-                            href: dpsUrl + "/prisoner/" + arrival.prisonNumber,
+                            href: dpsUrl + "/save-backlink?service=welcome-people-into-prison&returnPath=/prisoners/" + arrival.id + "/summary-with-record&redirectPath=/prisoner/" + arrival.prisonNumber,
                             attributes: {'data-qa':'dps-link'},
                             classes: "govuk-button--secondary moj-button-menu__item govuk-!-margin-left-3 govuk-!-margin-right-0 float-right"
                         }) }}


### PR DESCRIPTION
Button added to enable user to access prisoner profile  in DPS from wpip-ui pre-arrival prisoner summary page. 
User needs the “Reception user“ and “Released Prisoner Viewing” roles to see button

Verified role mappings with HAAR Team member
Reception Staff -> ROLE_PRISON_RECEPTION
Released Prisoner Viewing -> ROLE_INACTIVE_BOOKINGS

