### PR TITLE
DCS-1948 add button enabling user to view prisoner profile in DPS

### DIFF
--- a/server/routes/recentArrivals/index.ts
+++ b/server/routes/recentArrivals/index.ts
@@ -4,7 +4,6 @@ import RecentArrivalsController from './recentArrivalsController'
 import RecentArrivalsSearchController from './recentArrivalsSearchController'
 import Routes from '../../utils/routeBuilder'
 import { State } from './state'
-import Role from '../../authentication/role'
 import RecentArrivalsSummaryController from './recentArrivalsSummaryController'
 
 export default function routes(services: Services): Router {
@@ -20,7 +19,6 @@ export default function routes(services: Services): Router {
     .get('/recent-arrivals/search', checkSearchQueryPresent, recentArrivalsSearch.showSearch())
     .post('/recent-arrivals/search', checkSearchQueryPresent, recentArrivalsSearch.submitSearch())
 
-    .forRole(Role.PRISON_RECEPTION)
     .get('/recent-arrivals/:prisonNumber/summary', recentArrivalsSummaryController.view())
 
     .build()

--- a/server/views/pages/recentArrivals/recentArrivalsSummary.njk
+++ b/server/views/pages/recentArrivals/recentArrivalsSummary.njk
@@ -25,6 +25,12 @@
                 </div>
                 <div class="govuk-grid-column-one-half">
                     {{ govukButton({
+                        text: "View full prisoner profile",
+                        href: dpsUrl + "/save-backlink?service=welcome-people-into-prison&returnPath=/recent-arrivals/" + arrival.prisonNumber + "/summary&redirectPath=/prisoner/" + arrival.prisonNumber,
+                        classes: "govuk-button--secondary govuk-!-margin-left-3 float-right",
+                        attributes: {'data-qa':'dps-prisoner-profile-button'}
+                    }) }}
+                    {{ govukButton({
                         text: "Add a case note",
                         href: dpsUrl + "/save-backlink?service=welcome-people-into-prison&returnPath=/recent-arrivals/" + arrival.prisonNumber + "/summary&redirectPath=/prisoner/" + arrival.prisonNumber + "/add-case-note",
                         classes: "govuk-button--secondary float-right",


### PR DESCRIPTION
The save-backlink endpoint automatically creates a link in DPS enabling user to return to the summary page