### PR TITLE
DCS-1799 integration tests can stub multiple user roles

### DIFF
--- a/integration_tests/integration/bodyscan/bodyScan.cy.ts
+++ b/integration_tests/integration/bodyscan/bodyScan.cy.ts
@@ -9,7 +9,7 @@ const arrival = expectedArrivals.potentialMatch
 context('A user can record a body scan', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasMultipleMatches.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasMultipleMatches.cy.ts
@@ -41,7 +41,7 @@ const arrival = expectedArrivals.arrival({
 context('Arrival matches multiple records', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasNoMatchAndPncOnly.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasNoMatchAndPncOnly.cy.ts
@@ -22,7 +22,7 @@ const arrival = expectedArrivals.arrival({
 context('No match found', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/isSingleMatch.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/isSingleMatch.cy.ts
@@ -21,7 +21,7 @@ const prisonRecordDetails = expectedArrival.potentialMatches[0]
 context('Is Single Match', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')
     cy.task('stubExpectedArrivals', { caseLoadId: 'MDI', arrivals: [] })

--- a/integration_tests/integration/bookedtoday/arrivals/courtreturns/courtReturn.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/courtreturns/courtReturn.cy.ts
@@ -11,7 +11,7 @@ const prisonRecordDetails = expectedArrival.potentialMatches[0]
 context('Confirm court return added To roll', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/arrivals/resolvingTypesOfArrivals.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/resolvingTypesOfArrivals.cy.ts
@@ -44,7 +44,7 @@ const chosenMatch = arrival.potentialMatches[1]
 context('Redirect logic once a record for an arrival has been resolved', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.cy.ts
@@ -31,7 +31,7 @@ const matchedRecords = [
 context('Multiple existing records', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/arrivals/searchforexisting/searchForExisting.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/searchforexisting/searchForExisting.cy.ts
@@ -26,7 +26,7 @@ const singleMatch = [
 context('Search for existing spec', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/choosePrisoner.cy.ts
+++ b/integration_tests/integration/bookedtoday/choosePrisoner.cy.ts
@@ -11,7 +11,7 @@ import ReviewDetailsPage from '../../pages/bookedtoday/arrivals/reviewDetails'
 context('Choose Prisoner', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/transfers/transfer.cy.ts
+++ b/integration_tests/integration/bookedtoday/transfers/transfer.cy.ts
@@ -10,7 +10,7 @@ const expectedArrival = expectedArrivals.prisonTransfer
 context('Confirm transfer added To roll', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/unexpectedArrivals/multipleMatchingRecordsFound.cy.ts
+++ b/integration_tests/integration/bookedtoday/unexpectedArrivals/multipleMatchingRecordsFound.cy.ts
@@ -40,7 +40,7 @@ const arrival = expectedArrivals.arrival({
 context('Unexpected arrivals - multiple matching records', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/unexpectedArrivals/noMatchRecord.cy.ts
+++ b/integration_tests/integration/bookedtoday/unexpectedArrivals/noMatchRecord.cy.ts
@@ -12,7 +12,7 @@ import CheckAnswersForCreateNewRecordPage from '../../../pages/bookedtoday/arriv
 context('Unexpected arrivals - no matching records page', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/bookedtoday/unexpectedArrivals/singleMatchRecord.cy.ts
+++ b/integration_tests/integration/bookedtoday/unexpectedArrivals/singleMatchRecord.cy.ts
@@ -20,7 +20,7 @@ context('Unexpected arrivals - Single matching record found', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/featureNotAvailable.cy.ts
+++ b/integration_tests/integration/featureNotAvailable.cy.ts
@@ -15,7 +15,7 @@ import CheckTemporaryAbsencePage from '../pages/temporaryabsences/checkTemporary
 context('Feature not available', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')
     cy.task('stubMissingPrisonerImage')

--- a/integration_tests/integration/feedback.cy.ts
+++ b/integration_tests/integration/feedback.cy.ts
@@ -7,7 +7,7 @@ import HomePage from '../pages/homePage'
 context('A user can provide feedback', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/homePage.cy.ts
+++ b/integration_tests/integration/homePage.cy.ts
@@ -8,7 +8,7 @@ import expectedArrivals from '../mockApis/responses/expectedArrivals'
 context('A user can view the home page', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/login.cy.ts
+++ b/integration_tests/integration/login.cy.ts
@@ -7,7 +7,7 @@ import Role from '../../server/authentication/role'
 context('SignIn', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubUserCaseLoads')
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')

--- a/integration_tests/integration/recentArrivals/recentArrivals.cy.ts
+++ b/integration_tests/integration/recentArrivals/recentArrivals.cy.ts
@@ -16,7 +16,7 @@ const recentArrival = recentArrivalsResponse.arrival({})
 context('A user can view all recent arrivals', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/temporaryabsences/temporaryAbsence.cy.ts
+++ b/integration_tests/integration/temporaryabsences/temporaryAbsence.cy.ts
@@ -8,7 +8,7 @@ import CheckTemporaryAbsencePage from '../../pages/temporaryabsences/checkTempor
 context('Confirm temporary absence added', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/integration/temporaryabsences/temporaryAbsences.cy.ts
+++ b/integration_tests/integration/temporaryabsences/temporaryAbsences.cy.ts
@@ -7,7 +7,7 @@ import temporaryAbsences from '../../mockApis/responses/temporaryAbsences'
 context('A user can view all current temporary absences', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', Role.PRISON_RECEPTION)
+    cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubPrison', 'MDI')
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -5,12 +5,12 @@ import { getRequests, stubFor } from './wiremock'
 import tokenVerification from './tokenVerification'
 import Role from '../../server/authentication/role'
 
-const createToken = (role: Role) => {
+const createToken = (role: Role[]) => {
   const payload = {
     user_name: 'USER1',
     scope: ['read'],
     auth_source: 'nomis',
-    authorities: [role || ''],
+    authorities: role,
     jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
     client_id: 'clientid',
   }
@@ -94,7 +94,7 @@ const manageDetails = () =>
     },
   })
 
-const token = (role: Role) =>
+const token = (role: Role[]) =>
   stubFor({
     request: {
       method: 'POST',
@@ -156,7 +156,7 @@ const stubUserRoles = () =>
 export default {
   getSignInUrl,
   stubPing: (): Promise<[Response, Response]> => Promise.all([ping(), tokenVerification.stubPing()]),
-  stubSignIn: (role: Role): Promise<[Response, Response, Response, Response, Response, Response]> =>
+  stubSignIn: (role: Role[]): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(role), tokenVerification.stubVerifyToken()]),
   stubUser: (): Promise<[Response, Response]> => Promise.all([stubUser(), stubUserRoles()]),
 }

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -5,12 +5,12 @@ import { getRequests, stubFor } from './wiremock'
 import tokenVerification from './tokenVerification'
 import Role from '../../server/authentication/role'
 
-const createToken = (role: Role[]) => {
+const createToken = (roles: Role[]) => {
   const payload = {
     user_name: 'USER1',
     scope: ['read'],
     auth_source: 'nomis',
-    authorities: role,
+    authorities: roles,
     jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
     client_id: 'clientid',
   }


### PR DESCRIPTION
need to add multiple roles as the dpslink from pre-arrival prsioner summary has a button to the DPS profile and the button should show only if user has the two required roles