### PR TITLE
Dcs 1799 wpip UI add links from arrivals page to person summary

### DIFF
--- a/integration_tests/integration/bodyscan/bodyScan.cy.ts
+++ b/integration_tests/integration/bodyscan/bodyScan.cy.ts
@@ -3,6 +3,7 @@ import Role from '../../../server/authentication/role'
 import BodyScanPage from '../../pages/bodyscan/bodyScan'
 import expectedArrivals from '../../mockApis/responses/expectedArrivals'
 import BodyScanConfirmation from '../../pages/bodyscan/bodyScanConfirmation'
+import bodyScans from '../../mockApis/responses/bodyScans'
 
 const arrival = expectedArrivals.potentialMatch
 
@@ -20,12 +21,7 @@ context('A user can record a body scan', () => {
     cy.signIn()
     cy.task('stubGetBodyScan', {
       prisonNumber: arrival.prisonNumber,
-      details: {
-        prisonNumber: 'A1234AA',
-        bodyScanStatus: 'OK_TO_SCAN',
-        numberOfBodyScans: 10,
-        numberOfBodyScansRemaining: 106,
-      },
+      details: bodyScans.okToScan(),
     })
     const bodyScanPage = BodyScanPage.goTo(arrival.prisonNumber)
 
@@ -74,12 +70,7 @@ context('A user can record a body scan', () => {
     cy.signIn()
     cy.task('stubGetBodyScan', {
       prisonNumber: arrival.prisonNumber,
-      details: {
-        prisonNumber: 'A1234AA',
-        bodyScanStatus: 'CLOSE_TO_LIMIT',
-        numberOfBodyScans: 102,
-        numberOfBodyScansRemaining: 14,
-      },
+      details: bodyScans.closeToLimit(),
     })
     const bodyScanPage = BodyScanPage.goTo(arrival.prisonNumber)
 
@@ -91,12 +82,7 @@ context('A user can record a body scan', () => {
     cy.signIn()
     cy.task('stubGetBodyScan', {
       prisonNumber: arrival.prisonNumber,
-      details: {
-        prisonNumber: 'A1234AA',
-        bodyScanStatus: 'DO_NOT_SCAN',
-        numberOfBodyScans: 116,
-        numberOfBodyScansRemaining: 0,
-      },
+      details: bodyScans.doNotScan(),
     })
     const bodyScanPage = BodyScanPage.goTo(arrival.prisonNumber)
 

--- a/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasMultipleMatches.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasMultipleMatches.cy.ts
@@ -9,6 +9,7 @@ import CheckAnswersPage from '../../../../pages/bookedtoday/arrivals/confirmArri
 import ConfirmAddedToRollPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll'
 import SearchForExistingPage from '../../../../pages/bookedtoday/arrivals/searchforexisting/search/searchForExisting'
 import ReviewDetailsPage from '../../../../pages/bookedtoday/arrivals/reviewDetails'
+import PrisonerSummaryMoveOnlyPage from '../../../../pages/bookedtoday/prisonerSummaryMoveOnly'
 
 const arrival = expectedArrivals.arrival({
   fromLocationType: 'COURT',
@@ -59,6 +60,11 @@ context('Arrival matches multiple records', () => {
   })
 
   it('Can choose and confirm arrival', () => {
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
+
     const multipleMatchingRecordsPage = Page.verifyOnPage(MultipleMatchingRecordsPage)
     const personalDetails = multipleMatchingRecordsPage.arrival()
     personalDetails.fieldName('prisoner-name').should('contain', 'Bob Smith')
@@ -153,12 +159,22 @@ context('Arrival matches multiple records', () => {
   })
 
   it('should allow searching with different details', () => {
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
+
     const multipleMatchingRecordsPage = Page.verifyOnPage(MultipleMatchingRecordsPage)
     multipleMatchingRecordsPage.search().click()
     Page.verifyOnPage(SearchForExistingPage)
   })
 
   it('Should allow navigation to create a new record', () => {
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
+
     const multipleMatchingRecordsPage = Page.verifyOnPage(MultipleMatchingRecordsPage)
     multipleMatchingRecordsPage.createNewDetailsReveal().click()
     multipleMatchingRecordsPage.createNew().click()

--- a/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasNoMatchAndPncOnly.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/hasNoMatchAndPncOnly.cy.ts
@@ -11,6 +11,7 @@ import SexPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/sexPa
 import ImprisonmentStatusPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/imprisonmentStatus'
 import CheckAnswersForCreateNewRecordPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/checkAnswersForCreateNewRecord'
 import ConfirmAddedToRollPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll'
+import PrisonerSummaryMoveOnlyPage from '../../../../pages/bookedtoday/prisonerSummaryMoveOnly'
 
 const arrival = expectedArrivals.arrival({
   prisonNumber: null,
@@ -40,6 +41,11 @@ context('No match found', () => {
   })
 
   it('Check no match page', () => {
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
+
     const noMatchingRecordsFoundPage = Page.verifyOnPage(NoMatchingRecordsFoundPage)
     noMatchingRecordsFoundPage.perName().should('contain.text', 'Bob Smith')
     noMatchingRecordsFoundPage.perDob().should('contain.text', '1 January 1970')
@@ -51,6 +57,11 @@ context('No match found', () => {
   })
 
   it('Change name', () => {
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
+
     const noMatchingRecordsFoundPage = Page.verifyOnPage(NoMatchingRecordsFoundPage)
     noMatchingRecordsFoundPage.continue().click()
     {
@@ -80,6 +91,11 @@ context('No match found', () => {
   })
 
   it('Change date of birth', () => {
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
+
     const noMatchingRecordsFoundPage = Page.verifyOnPage(NoMatchingRecordsFoundPage)
     noMatchingRecordsFoundPage.continue().click()
     {
@@ -121,6 +137,10 @@ context('No match found', () => {
       potentialMatches: [],
     })
     cy.task('stubExpectedArrival', arrivalWithNoSex)
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
 
     const noMatchingRecordsFoundPage = Page.verifyOnPage(NoMatchingRecordsFoundPage)
     noMatchingRecordsFoundPage.continue().click()
@@ -135,6 +155,11 @@ context('No match found', () => {
   })
 
   it('Can process arrival', () => {
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.breadcrumbs().should('exist')
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
+
     const noMatchingRecordsFoundPage = Page.verifyOnPage(NoMatchingRecordsFoundPage)
     noMatchingRecordsFoundPage.continue().click()
 

--- a/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/isSingleMatch.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/autoMatchingRecords/isSingleMatch.cy.ts
@@ -1,4 +1,4 @@
-import Page from '../../../../pages/page'
+import Page, { PageConstructor } from '../../../../pages/page'
 import SingleMatchingRecordFoundPage from '../../../../pages/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFound'
 import ImprisonmentStatusPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/imprisonmentStatus'
 import CheckAnswersPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/checkAnswers'
@@ -9,6 +9,7 @@ import ChoosePrisonerPage from '../../../../pages/bookedtoday/choosePrisoner'
 import MovementReasonsPage from '../../../../pages/bookedtoday/arrivals/confirmArrival/movementReasons'
 import SearchForExistingPage from '../../../../pages/bookedtoday/arrivals/searchforexisting/search/searchForExisting'
 import ReviewDetailsPage from '../../../../pages/bookedtoday/arrivals/reviewDetails'
+import PrisonerSummaryWithRecordPage from '../../../../pages/bookedtoday/prisonerSummaryWithRecord'
 
 const expectedArrival = expectedArrivals.arrival({
   fromLocationType: 'COURT',
@@ -24,7 +25,7 @@ context('Is Single Match', () => {
     cy.task('stubSignIn', [Role.PRISON_RECEPTION])
     cy.task('stubAuthUser')
     cy.task('stubUserCaseLoads')
-    cy.task('stubExpectedArrivals', { caseLoadId: 'MDI', arrivals: [] })
+    cy.task('stubExpectedArrivals', { caseLoadId: 'MDI', arrivals: [expectedArrival] })
     cy.task('stubTransfers', { caseLoadId: 'MDI', transfers: [] })
     cy.task('stubMissingPrisonerImage')
     cy.task('stubPrison', 'MDI')
@@ -35,67 +36,80 @@ context('Is Single Match', () => {
 
   it('Can confirm single record match', () => {
     cy.task('stubExpectedArrival', expectedArrival)
+    cy.task('stubGetBodyScan', {
+      prisonNumber: 'A1234BC',
+      bodyScanStatus: 'OK_TO_SCAN',
+      numberOfBodyScans: 1,
+      numberOfBodyScansRemaining: 10,
+    })
+
     cy.signIn()
 
-    const singleMatchingRecordFoundPage = ChoosePrisonerPage.selectPrisoner(
-      expectedArrival.id,
-      SingleMatchingRecordFoundPage
+    const choosePrisonerPage = ChoosePrisonerPage.goTo()
+    choosePrisonerPage.expectedArrivalsFromCourt(1).click()
+
+    const prisonerSummaryWithRecordPage = new PrisonerSummaryWithRecordPage(
+      `${expectedArrival.lastName}, ${expectedArrival.firstName}`
     )
-    singleMatchingRecordFoundPage.backNavigation().should('exist')
-    singleMatchingRecordFoundPage.prisonerSplitView.contains(expectedArrival, prisonRecordDetails)
-    singleMatchingRecordFoundPage.continue().click()
 
-    const imprisonmentStatusPage = Page.verifyOnPage(ImprisonmentStatusPage)
-    imprisonmentStatusPage.backNavigation().should('exist')
-    imprisonmentStatusPage.continue().click()
-    imprisonmentStatusPage.hasError('Select why this person is in prison')
-    imprisonmentStatusPage.imprisonmentStatusRadioButton('determinate-sentence').click()
-    imprisonmentStatusPage.continue().click()
+    prisonerSummaryWithRecordPage.checkOnPage()
+    prisonerSummaryWithRecordPage.compliancePanelText().should('not.exist')
 
-    const movementReasonPage = Page.verifyOnPage(MovementReasonsPage)
-    movementReasonPage.continue().click()
-    movementReasonPage.hasError('Select the type of fixed-length sentence')
-    movementReasonPage.movementReasonRadioButton('26').click()
-    movementReasonPage.continue().click()
+    // singleMatchingRecordFoundPage.backNavigation().should('exist')
+    // singleMatchingRecordFoundPage.prisonerSplitView.contains(expectedArrival, prisonRecordDetails)
+    // singleMatchingRecordFoundPage.continue().click()
 
-    const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage)
-    checkAnswersPage.checkDetails({
-      name: 'Sam Smith',
-      dob: '1 February 1970',
-      prisonNumber: 'A1234BC',
-      pncNumber: '01/4567A',
-      sex: 'Male',
-      reason: 'Sentenced - fixed length of time - Extended sentence for public protection',
-    })
-    cy.task('stubCreateOffenderRecordAndBooking', { arrivalId: expectedArrival.id })
-    checkAnswersPage.addToRoll().click()
+    // const imprisonmentStatusPage = Page.verifyOnPage(ImprisonmentStatusPage)
+    // imprisonmentStatusPage.backNavigation().should('exist')
+    // imprisonmentStatusPage.continue().click()
+    // imprisonmentStatusPage.hasError('Select why this person is in prison')
+    // imprisonmentStatusPage.imprisonmentStatusRadioButton('determinate-sentence').click()
+    // imprisonmentStatusPage.continue().click()
 
-    const confirmAddedToRollPage = Page.verifyOnPage(ConfirmAddedToRollPage)
-    confirmAddedToRollPage.checkDetails({
-      name: 'Sam Smith',
-      prison: 'Moorland (HMP & YOI)',
-      prisonNumber: 'A1234BC',
-      locationName: 'Reception',
-    })
-    confirmAddedToRollPage.addCaseNote('A1234BC').exists()
-    confirmAddedToRollPage.viewEstablishmentRoll().exists()
-    confirmAddedToRollPage.addAnotherToRoll().click()
+    // const movementReasonPage = Page.verifyOnPage(MovementReasonsPage)
+    // movementReasonPage.continue().click()
+    // movementReasonPage.hasError('Select the type of fixed-length sentence')
+    // movementReasonPage.movementReasonRadioButton('26').click()
+    // movementReasonPage.continue().click()
 
-    Page.verifyOnPage(ChoosePrisonerPage)
+    // const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage)
+    // checkAnswersPage.checkDetails({
+    //   name: 'Sam Smith',
+    //   dob: '1 February 1970',
+    //   prisonNumber: 'A1234BC',
+    //   pncNumber: '01/4567A',
+    //   sex: 'Male',
+    //   reason: 'Sentenced - fixed length of time - Extended sentence for public protection',
+    // })
+    // cy.task('stubCreateOffenderRecordAndBooking', { arrivalId: expectedArrival.id })
+    // checkAnswersPage.addToRoll().click()
 
-    cy.task('getConfirmationRequest', expectedArrival.id).then(request => {
-      expect(request).to.deep.equal({
-        dateOfBirth: '1970-02-01',
-        firstName: 'Sam',
-        sex: 'M',
-        imprisonmentStatus: 'SENT',
-        lastName: 'Smith',
-        movementReasonCode: '26',
-        prisonId: 'MDI',
-        prisonNumber: 'A1234BC',
-        fromLocationId: 'MDI',
-      })
-    })
+    // const confirmAddedToRollPage = Page.verifyOnPage(ConfirmAddedToRollPage)
+    // confirmAddedToRollPage.checkDetails({
+    //   name: 'Sam Smith',
+    //   prison: 'Moorland (HMP & YOI)',
+    //   prisonNumber: 'A1234BC',
+    //   locationName: 'Reception',
+    // })
+    // confirmAddedToRollPage.addCaseNote('A1234BC').exists()
+    // confirmAddedToRollPage.viewEstablishmentRoll().exists()
+    // confirmAddedToRollPage.addAnotherToRoll().click()
+
+    // Page.verifyOnPage(ChoosePrisonerPage)
+
+    // cy.task('getConfirmationRequest', expectedArrival.id).then(request => {
+    //   expect(request).to.deep.equal({
+    //     dateOfBirth: '1970-02-01',
+    //     firstName: 'Sam',
+    //     sex: 'M',
+    //     imprisonmentStatus: 'SENT',
+    //     lastName: 'Smith',
+    //     movementReasonCode: '26',
+    //     prisonId: 'MDI',
+    //     prisonNumber: 'A1234BC',
+    //     fromLocationId: 'MDI',
+    //   })
+    // })
   })
 
   it('Should allow navigation to search for alternative', () => {

--- a/integration_tests/integration/bookedtoday/arrivals/courtreturns/courtReturn.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/courtreturns/courtReturn.cy.ts
@@ -4,6 +4,8 @@ import expectedArrivals from '../../../../mockApis/responses/expectedArrivals'
 import ChoosePrisonerPage from '../../../../pages/bookedtoday/choosePrisoner'
 import ConfirmCourtReturnAddedToRollPage from '../../../../pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll'
 import CheckCourtReturnPage from '../../../../pages/bookedtoday/arrivals/courtreturns/checkCourtReturn'
+import PrisonerSummaryWithRecordPage from '../../../../pages/bookedtoday/prisonerSummaryWithRecord'
+import bodyScans from '../../../../mockApis/responses/bodyScans'
 
 const expectedArrival = expectedArrivals.court.current
 const prisonRecordDetails = expectedArrival.potentialMatches[0]
@@ -23,17 +25,34 @@ context('Confirm court return added To roll', () => {
     cy.task('stubTransfers', { caseLoadId: 'MDI', transfers: [] })
     cy.task('stubConfirmCourtReturn', expectedArrival.id)
     cy.task('stubRetrieveMultipleBodyScans', [])
+    cy.task('stubGetBodyScan', bodyScans.okToScan())
+    cy.task('stubPrisonerDetails', { ...prisonRecordDetails, arrivalType: 'NEW_BOOKING' })
+
     cy.signIn()
   })
 
   it('Can back out of confirmation', () => {
-    const checkCourtReturnPage = ChoosePrisonerPage.selectPrisoner(expectedArrival.id, CheckCourtReturnPage)
+    const choosePrisonerPage = ChoosePrisonerPage.goTo()
+    choosePrisonerPage.arrivalFrom('COURT')(1).confirm().click()
+    const prisonerSummaryWithRecordPage = new PrisonerSummaryWithRecordPage(
+      `${expectedArrival.lastName}, ${expectedArrival.firstName}`
+    )
+    prisonerSummaryWithRecordPage.checkOnPage()
+    prisonerSummaryWithRecordPage.confirmArrival().click()
+    const checkCourtReturnPage = Page.verifyOnPage(CheckCourtReturnPage)
     checkCourtReturnPage.returnToArrivalsList().click()
     Page.verifyOnPage(ChoosePrisonerPage)
   })
 
   it('Can confirm court arrivals', () => {
-    const checkCourtReturnPage = ChoosePrisonerPage.selectPrisoner(expectedArrival.id, CheckCourtReturnPage)
+    const choosePrisonerPage = ChoosePrisonerPage.goTo()
+    choosePrisonerPage.arrivalFrom('COURT')(1).confirm().click()
+    const prisonerSummaryWithRecordPage = new PrisonerSummaryWithRecordPage(
+      `${expectedArrival.lastName}, ${expectedArrival.firstName}`
+    )
+    prisonerSummaryWithRecordPage.checkOnPage()
+    prisonerSummaryWithRecordPage.confirmArrival().click()
+    const checkCourtReturnPage = Page.verifyOnPage(CheckCourtReturnPage)
 
     checkCourtReturnPage.prisonerSplitView.contains(expectedArrival, prisonRecordDetails)
 

--- a/integration_tests/integration/bookedtoday/arrivals/resolvingTypesOfArrivals.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/resolvingTypesOfArrivals.cy.ts
@@ -10,6 +10,7 @@ import ConfirmTransferAddedToRollPage from '../../../pages/bookedtoday/transfers
 import CheckCourtReturnPage from '../../../pages/bookedtoday/arrivals/courtreturns/checkCourtReturn'
 import ConfirmCourtReturnAddedToRollPage from '../../../pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll'
 import FeatureNotAvailablePage from '../../../pages/featureNotAvailable'
+import PrisonerSummaryWithRecordPage from '../../../pages/bookedtoday/prisonerSummaryWithRecord'
 
 const arrival = expectedArrivals.arrival({
   fromLocationType: 'COURT',
@@ -59,6 +60,9 @@ context('Redirect logic once a record for an arrival has been resolved', () => {
 
     const choosePrisonerPage = ChoosePrisonerPage.goTo()
     choosePrisonerPage.arrivalFrom('COURT')(1).confirm().click()
+    const prisonerSummaryWithRecordPage = new PrisonerSummaryWithRecordPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryWithRecordPage.checkOnPage()
+    prisonerSummaryWithRecordPage.confirmArrival().click()
   })
 
   it('Can choose and confirm arrival of a temporay absence', () => {

--- a/integration_tests/integration/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/searchforexisting/multipleExistingRecordsFound.cy.ts
@@ -9,6 +9,7 @@ import Role from '../../../../../server/authentication/role'
 import expectedArrivals from '../../../../mockApis/responses/expectedArrivals'
 import ChangePrisonNumberPage from '../../../../pages/bookedtoday/arrivals/searchforexisting/search/changePrisonNumber'
 import ChangePncNumberPage from '../../../../pages/bookedtoday/arrivals/searchforexisting/search/changePncNumber'
+import PrisonerSummaryMoveOnlyPage from '../../../../pages/bookedtoday/prisonerSummaryMoveOnly'
 
 const matchedRecords = [
   {
@@ -53,6 +54,9 @@ context('Multiple existing records', () => {
 
     const choosePrisonerPage = ChoosePrisonerPage.goTo()
     choosePrisonerPage.arrivalFrom('COURT')(1).confirm().click()
+    const prisonerSummaryWithRecordPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryWithRecordPage.checkOnPage()
+    prisonerSummaryWithRecordPage.confirmArrival().click()
   })
 
   it('Processing multiple matches', () => {

--- a/integration_tests/integration/bookedtoday/arrivals/searchforexisting/searchForExisting.cy.ts
+++ b/integration_tests/integration/bookedtoday/arrivals/searchforexisting/searchForExisting.cy.ts
@@ -10,6 +10,7 @@ import ChangeDateOfBirthPage from '../../../../pages/bookedtoday/arrivals/change
 import ChangePrisonNumberPage from '../../../../pages/bookedtoday/arrivals/searchforexisting/search/changePrisonNumber'
 import ChangePncNumberPage from '../../../../pages/bookedtoday/arrivals/searchforexisting/search/changePncNumber'
 import ReviewDetailsPage from '../../../../pages/bookedtoday/arrivals/reviewDetails'
+import PrisonerSummaryMoveOnlyPage from '../../../../pages/bookedtoday/prisonerSummaryMoveOnly'
 
 const singleMatch = [
   {
@@ -47,6 +48,9 @@ context('Search for existing spec', () => {
 
     const choosePrisonerPage = ChoosePrisonerPage.goTo()
     choosePrisonerPage.arrivalFrom('CUSTODY_SUITE')(1).confirm().click()
+    const prisonerSummaryMoveOnlyPage = new PrisonerSummaryMoveOnlyPage(`${arrival.lastName}, ${arrival.firstName}`)
+    prisonerSummaryMoveOnlyPage.checkOnPage()
+    prisonerSummaryMoveOnlyPage.confirmArrival().click()
   })
 
   it('Change name', () => {

--- a/integration_tests/integration/recentArrivals/recentArrivals.cy.ts
+++ b/integration_tests/integration/recentArrivals/recentArrivals.cy.ts
@@ -5,6 +5,7 @@ import RecentArrivalsPage from '../../pages/recentArrivals/recentArrivals'
 import RecentArrivalsSearchPage from '../../pages/recentArrivals/recentArrivalsSearch'
 import PrisonerSummaryPage from '../../pages/recentArrivals/prisonerSummary'
 import recentArrivalsResponse from '../../mockApis/responses/recentArrivals'
+import bodyScans from '../../mockApis/responses/bodyScans'
 
 const today = moment().format('YYYY-MM-DD')
 const oneDayAgo = moment().subtract(1, 'days').format('YYYY-MM-DD')
@@ -30,10 +31,7 @@ context('A user can view all recent arrivals', () => {
       },
       { prisonNumber: 'G0015GF', bodyScanStatus: 'OK_TO_SCAN', numberOfBodyScans: 1 },
     ])
-    cy.task('stubGetPrisonerDetails', {
-      prisonNumber: recentArrival.prisonNumber,
-      details: recentArrival,
-    })
+    cy.task('stubPrisonerDetails', recentArrival)
   })
 
   it('Should display list of recent arrivals for last three days and handle no arrivals for a day', () => {
@@ -118,14 +116,12 @@ context('A user can view all recent arrivals', () => {
   it('Should display prisoner summary page', () => {
     cy.task('stubGetBodyScan', {
       prisonNumber: recentArrival.prisonNumber,
-      details: {
-        prisonNumber: recentArrival.prisonNumber,
-        bodyScanStatus: 'OK_TO_SCAN',
-        numberOfBodyScans: 1,
-        numberOfBodyScansRemaining: 100,
-      },
+      details: bodyScans.okToScan(),
     })
 
+    cy.task('stubPrisonerDetails', {
+      details: recentArrival,
+    })
     cy.signIn()
     const recentArrivalsPage = RecentArrivalsPage.goTo()
     recentArrivalsPage.recentArrivals(1, today).name().click()
@@ -138,12 +134,7 @@ context('A user can view all recent arrivals', () => {
   it('Should display correct message when body scan count is close to limit', () => {
     cy.task('stubGetBodyScan', {
       prisonNumber: recentArrival.prisonNumber,
-      details: {
-        prisonNumber: recentArrival.prisonNumber,
-        bodyScanStatus: 'CLOSE_TO_LIMIT',
-        numberOfBodyScans: 114,
-        numberOfBodyScansRemaining: 1,
-      },
+      details: bodyScans.closeToLimit(recentArrival.prisonNumber),
     })
 
     cy.signIn()
@@ -160,12 +151,7 @@ context('A user can view all recent arrivals', () => {
   it('Should display correct message when body scan count limit reached', () => {
     cy.task('stubGetBodyScan', {
       prisonNumber: recentArrival.prisonNumber,
-      details: {
-        prisonNumber: recentArrival.prisonNumber,
-        bodyScanStatus: 'DO_NOT_SCAN',
-        numberOfBodyScans: 120,
-        numberOfBodyScansRemaining: 0,
-      },
+      details: bodyScans.doNotScan(),
     })
 
     cy.signIn()

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -94,7 +94,7 @@ const manageDetails = () =>
     },
   })
 
-const token = (role: Role[]) =>
+const token = (roles: Role[]) =>
   stubFor({
     request: {
       method: 'POST',
@@ -107,7 +107,7 @@ const token = (role: Role[]) =>
         Location: 'http://localhost:3007/sign-in/callback?code=codexxxx&state=stateyyyy',
       },
       jsonBody: {
-        access_token: createToken(role),
+        access_token: createToken(roles),
         token_type: 'bearer',
         user_name: 'USER1',
         expires_in: 599,
@@ -156,7 +156,7 @@ const stubUserRoles = () =>
 export default {
   getSignInUrl,
   stubPing: (): Promise<[Response, Response]> => Promise.all([ping(), tokenVerification.stubPing()]),
-  stubSignIn: (role: Role[]): Promise<[Response, Response, Response, Response, Response, Response]> =>
-    Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(role), tokenVerification.stubVerifyToken()]),
+  stubSignIn: (roles: Role[]): Promise<[Response, Response, Response, Response, Response, Response]> =>
+    Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(roles), tokenVerification.stubVerifyToken()]),
   stubUser: (): Promise<[Response, Response]> => Promise.all([stubUser(), stubUserRoles()]),
 }

--- a/integration_tests/mockApis/responses/bodyScans.ts
+++ b/integration_tests/mockApis/responses/bodyScans.ts
@@ -1,0 +1,20 @@
+export default {
+  okToScan: (prisonNumber = 'A1234BC') => ({
+    prisonNumber,
+    bodyScanStatus: 'OK_TO_SCAN',
+    numberOfBodyScans: 10,
+    numberOfBodyScansRemaining: 106,
+  }),
+  closeToLimit: (prisonNumber = 'A1234BC') => ({
+    prisonNumber,
+    bodyScanStatus: 'CLOSE_TO_LIMIT',
+    numberOfBodyScans: 114,
+    numberOfBodyScansRemaining: 1,
+  }),
+  doNotScan: (prisonNumber = 'A1234BC') => ({
+    prisonNumber,
+    bodyScanStatus: 'DO_NOT_SCAN',
+    numberOfBodyScans: 116,
+    numberOfBodyScansRemaining: 0,
+  }),
+}

--- a/integration_tests/mockApis/welcome.ts
+++ b/integration_tests/mockApis/welcome.ts
@@ -65,25 +65,6 @@ export default {
       },
     })
   },
-  stubGetPrisonerDetails: ({
-    prisonNumber,
-    details,
-  }: {
-    prisonNumber: string
-    details: Record<string, unknown>
-  }): SuperAgentRequest => {
-    return stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: `/welcome/prisoners/${prisonNumber}`,
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: details,
-      },
-    })
-  },
   stubRecentArrivals: ({
     caseLoadId,
     recentArrivals,

--- a/integration_tests/pages/bookedtoday/choosePrisoner.ts
+++ b/integration_tests/pages/bookedtoday/choosePrisoner.ts
@@ -15,7 +15,7 @@ export default class ChoosePrisonerPage extends Page {
     return Page.verifyOnPage(expectedPage)
   }
 
-  expectedArrivalsFromCourt = (index: number): PageElement => cy.get(`[data-qa=COURT-title-${index}] > a`)
+  expectedArrivalsFromCourt = (index: number): PageElement => cy.get(`[data-qa=COURT-title-${index}]`)
 
   noExpectedArrivalsFromCourt = (): PageElement => cy.get('[data-qa=no-arrivals-from-court]')
 

--- a/integration_tests/pages/bookedtoday/choosePrisoner.ts
+++ b/integration_tests/pages/bookedtoday/choosePrisoner.ts
@@ -11,11 +11,11 @@ export default class ChoosePrisonerPage extends Page {
   }
 
   static selectPrisoner<T extends Page>(id: string, expectedPage: PageConstructor<T>): T {
-    cy.visit(`/confirm-arrival/choose-prisoner/${id}`)
+    cy.visit(`/confirm-arrival/choose-prisoner/${id}/summary`)
     return Page.verifyOnPage(expectedPage)
   }
 
-  expectedArrivalsFromCourt = (index: number): PageElement => cy.get(`[data-qa=COURT-title-${index}]`)
+  expectedArrivalsFromCourt = (index: number): PageElement => cy.get(`[data-qa=COURT-title-${index}] > a`)
 
   noExpectedArrivalsFromCourt = (): PageElement => cy.get('[data-qa=no-arrivals-from-court]')
 

--- a/integration_tests/pages/bookedtoday/prisonerSummaryMoveOnly.ts
+++ b/integration_tests/pages/bookedtoday/prisonerSummaryMoveOnly.ts
@@ -1,6 +1,6 @@
 import Page, { PageElement } from '../page'
 
-export default class PrisonerSummaryWithRecordPage extends Page {
+export default class PrisonerSummaryMoveOnlyPage extends Page {
   constructor(title: string) {
     super(title, { hasBackLink: false })
   }

--- a/integration_tests/pages/bookedtoday/prisonerSummaryWithRecord.ts
+++ b/integration_tests/pages/bookedtoday/prisonerSummaryWithRecord.ts
@@ -1,0 +1,9 @@
+import Page, { PageElement } from '../page'
+
+export default class PrisonerSummaryWithRecordPage extends Page {
+  constructor(title: string) {
+    super(title, { hasBackLink: false })
+  }
+
+  compliancePanelText = (): PageElement => cy.get('[data-qa="compliance-panel-text"]')
+}

--- a/server/routes/bookedtoday/index.ts
+++ b/server/routes/bookedtoday/index.ts
@@ -2,6 +2,8 @@ import type { Router } from 'express'
 import type { Services } from '../../services'
 
 import ChoosePrisonerController from './choosePrisonerController'
+import SummaryController from './summaryController'
+
 import transferRoutes from './transfers'
 import arrivalRoutes from './arrivals'
 import unexpectedArrivalsRoutes from './unexpectedArrivals'
@@ -13,10 +15,12 @@ export default function routes(services: Services): Router {
   const choosePrisonerController = new ChoosePrisonerController(services.expectedArrivalsService)
   const summaryWithRecordController = new SummaryWithRecordController(services.expectedArrivalsService)
   const summaryMoveOnlyController = new SummaryMoveOnlyController(services.expectedArrivalsService)
+  const summaryController = new SummaryController(services.expectedArrivalsService)
 
   return Routes.forAnyRole()
     .get('/confirm-arrival/choose-prisoner', choosePrisonerController.view())
     .get('/confirm-arrival/choose-prisoner/:id', choosePrisonerController.redirectToConfirm())
+    .get('/confirm-arrival/choose-prisoner/:id/summary', summaryController.redirectToSummary())
 
     .get('/prisoners/:id/summary-with-record', summaryWithRecordController.view())
     .get('/prisoners/:id/summary-move-only', summaryMoveOnlyController.view())

--- a/server/routes/bookedtoday/index.ts
+++ b/server/routes/bookedtoday/index.ts
@@ -18,9 +18,9 @@ export default function routes(services: Services): Router {
   const summaryController = new SummaryController(services.expectedArrivalsService)
 
   return Routes.forAnyRole()
+    .get('/confirm-arrival/choose-prisoner/:id/summary', summaryController.redirectToSummary())
     .get('/confirm-arrival/choose-prisoner', choosePrisonerController.view())
     .get('/confirm-arrival/choose-prisoner/:id', choosePrisonerController.redirectToConfirm())
-    .get('/confirm-arrival/choose-prisoner/:id/summary', summaryController.redirectToSummary())
 
     .get('/prisoners/:id/summary-with-record', summaryWithRecordController.view())
     .get('/prisoners/:id/summary-move-only', summaryMoveOnlyController.view())

--- a/server/routes/bookedtoday/summaryController.test.ts
+++ b/server/routes/bookedtoday/summaryController.test.ts
@@ -1,0 +1,108 @@
+import type { Arrival } from 'welcome'
+import type { Express } from 'express'
+import request from 'supertest'
+import { appWithAllRoutes } from '../__testutils/appSetup'
+import { createMockExpectedArrivalsService } from '../../services/__testutils/mocks'
+import { MatchType, WithMatchType } from '../../services/matchTypeDecorator'
+
+let app: Express
+const expectedArrivalsService = createMockExpectedArrivalsService()
+
+beforeEach(() => {
+  app = appWithAllRoutes({ services: { expectedArrivalsService } })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /confirm-arrival/choose-prisoner/:moveId/summary', () => {
+  const arrival = ({ matchType }: { matchType: MatchType }) =>
+    ({
+      id: '1111-2222-3333-4444',
+      matchType,
+    } as WithMatchType<Arrival>)
+
+  describe('Summary controller', () => {
+    it('should redirect to /summary-with-record for COURT_RETURN', () => {
+      expectedArrivalsService.getArrival.mockResolvedValue(
+        arrival({
+          matchType: MatchType.COURT_RETURN,
+        })
+      )
+      return request(app)
+        .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Location', '/prisoners/1111-2222-3333-4444/summary-with-record')
+    })
+
+    it('should redirect to /summary-with-record for SINGLE_MATCH', () => {
+      expectedArrivalsService.getArrival.mockResolvedValue(
+        arrival({
+          matchType: MatchType.SINGLE_MATCH,
+        })
+      )
+      return request(app)
+        .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Location', '/prisoners/1111-2222-3333-4444/summary-with-record')
+    })
+
+    it('should redirect to /summary-move-only when MULTIPLE_POTENTIAL_MATCHES', () => {
+      expectedArrivalsService.getArrival.mockResolvedValue(
+        arrival({
+          matchType: MatchType.MULTIPLE_POTENTIAL_MATCHES,
+        })
+      )
+      return request(app)
+        .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Location', '/prisoners/1111-2222-3333-4444/summary-move-only')
+    })
+
+    it('should redirect to /summary-move-only when NO_MATCH', () => {
+      expectedArrivalsService.getArrival.mockResolvedValue(
+        arrival({
+          matchType: MatchType.NO_MATCH,
+        })
+      )
+      return request(app)
+        .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Location', '/prisoners/1111-2222-3333-4444/summary-move-only')
+    })
+
+    it('should redirect to /summary-move-only when INSUFFICIENT_INFO', () => {
+      expectedArrivalsService.getArrival.mockResolvedValue(
+        arrival({
+          matchType: MatchType.INSUFFICIENT_INFO,
+        })
+      )
+      return request(app)
+        .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Location', '/prisoners/1111-2222-3333-4444/summary-move-only')
+    })
+
+    it('should call service method correctly', () => {
+      expectedArrivalsService.getArrival.mockResolvedValue(
+        arrival({
+          matchType: MatchType.SINGLE_MATCH,
+        })
+      )
+      return request(app)
+        .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
+        .expect(res => {
+          expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('aaa-111-222')
+        })
+    })
+
+    it('should handle unexpected server error', () => {
+      expectedArrivalsService.getArrival.mockRejectedValue(new Error('an error occurred'))
+      return request(app)
+        .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
+        .expect(500)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+    })
+  })
+})

--- a/server/routes/bookedtoday/summaryController.ts
+++ b/server/routes/bookedtoday/summaryController.ts
@@ -1,0 +1,28 @@
+import type { RequestHandler } from 'express'
+import type { ExpectedArrivalsService } from '../../services'
+import { MatchType } from '../../services/matchTypeDecorator'
+
+export default class SummaryController {
+  public constructor(private readonly expectedArrivalsService: ExpectedArrivalsService) {}
+
+  public redirectToSummary(): RequestHandler {
+    return async (req, res) => {
+      const { id } = req.params
+
+      const arrival = await this.expectedArrivalsService.getArrival(id)
+      switch (arrival.matchType) {
+        case MatchType.COURT_RETURN:
+        case MatchType.SINGLE_MATCH:
+          return res.redirect(`/prisoners/${arrival.id}/summary-with-record`)
+
+        case MatchType.MULTIPLE_POTENTIAL_MATCHES:
+        case MatchType.NO_MATCH:
+        case MatchType.INSUFFICIENT_INFO:
+          return res.redirect(`/prisoners/${arrival.id}/summary-move-only`)
+
+        default:
+          throw new Error(`Invalid matchType: ${arrival.matchType}`)
+      }
+    }
+  }
+}

--- a/server/routes/bookedtoday/summaryWithRecordController.test.ts
+++ b/server/routes/bookedtoday/summaryWithRecordController.test.ts
@@ -108,7 +108,7 @@ describe('GET /prisoner/:id/summary-with-record', () => {
         .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('[data-qa=dps-link]').length).toBe(1)
+          expect($('[data-qa=prisoner-profile]').length).toBe(1)
         })
     })
     it('should not be displayed without Prison Reception role', () => {
@@ -123,7 +123,7 @@ describe('GET /prisoner/:id/summary-with-record', () => {
         .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('[data-qa=dps-link]').length).toBe(0)
+          expect($('[data-qa=prisoner-profile]').length).toBe(0)
         })
     })
 
@@ -139,8 +139,62 @@ describe('GET /prisoner/:id/summary-with-record', () => {
         .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(res => {
           const $ = cheerio.load(res.text)
-          expect($('[data-qa=dps-link]').length).toBe(0)
+          expect($('[data-qa=prisoner-profile]').length).toBe(0)
         })
     })
+
+    it('should not display the scan compliance panel', () => {
+      arrivalAndSummaryDetails.summary.bodyScanStatus = 'OK_TO_SCAN'
+
+      app = appWithAllRoutes({
+        services: { expectedArrivalsService },
+        roles: [Role.PRISON_RECEPTION],
+      })
+
+      return request(app)
+        .get('/prisoners/1111-1111-1111-1111/summary-with-record')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('.compliance-panel').length).toBe(0)
+        })
+    })
+  })
+
+  it("should not display the 'close to limit' scan compliance panel", () => {
+    arrivalAndSummaryDetails.summary.bodyScanStatus = 'CLOSE_TO_LIMIT'
+
+    app = appWithAllRoutes({
+      services: { expectedArrivalsService },
+      roles: [Role.PRISON_RECEPTION],
+    })
+
+    return request(app)
+      .get('/prisoners/1111-1111-1111-1111/summary-with-record')
+      .expect(200)
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa="close-to-limit"]').length).toBe(1)
+      })
+  })
+
+  it("should display the 'do not scan' compliance panel", () => {
+    arrivalAndSummaryDetails.summary.bodyScanStatus = 'DO_NOT_SCAN'
+
+    app = appWithAllRoutes({
+      services: { expectedArrivalsService },
+      roles: [Role.PRISON_RECEPTION],
+    })
+
+    return request(app)
+      .get('/prisoners/1111-1111-1111-1111/summary-with-record')
+      .expect(200)
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa="do-not-scan"]').length).toBe(1)
+      })
   })
 })

--- a/server/views/pages/bookedtoday/summaryMoveOnly.njk
+++ b/server/views/pages/bookedtoday/summaryMoveOnly.njk
@@ -29,7 +29,8 @@
                     {{ govukButton({
                         text: "Confirm arrival",
                         href: "/confirm-arrival/choose-prisoner/" + arrival.id,
-                        classes: "float-right"
+                        classes: "float-right",
+                        attributes: {'data-qa':'confirm-arrival'}
                     }) }}
                 </div>
             </div>

--- a/server/views/pages/bookedtoday/summaryWithRecord.njk
+++ b/server/views/pages/bookedtoday/summaryWithRecord.njk
@@ -28,14 +28,15 @@
                         {{ govukButton({
                             text: "View full prisoner profile",
                             href: dpsUrl + "/save-backlink?service=welcome-people-into-prison&returnPath=/prisoners/" + arrival.id + "/summary-with-record&redirectPath=/prisoner/" + arrival.prisonNumber,
-                            attributes: {'data-qa':'dps-link'},
+                            attributes: {'data-qa':'prisoner-profile'},
                             classes: "govuk-button--secondary moj-button-menu__item govuk-!-margin-left-3 govuk-!-margin-right-0 float-right"
                         }) }}
                     {% endif %}
                     {{ govukButton({
                         text: "Confirm arrival",
                         href: "/confirm-arrival/choose-prisoner/" + arrival.id,
-                        classes: "float-right"
+                        classes: "float-right",
+                        attributes: {'data-qa':'confirm-arrival'}
                     }) }}
                 </div>
             </div>
@@ -82,13 +83,13 @@
                         ]
                     }) }}
                     {% if summary.bodyScanStatus === 'DO_NOT_SCAN' %}
-                        <div class="compliance-panel compliance-panel--red">
+                        <div class="compliance-panel compliance-panel--red" data-qa="do-not-scan">
                             <p class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold">
                                 Do not scan – annual body scan limit reached
                             </p>
                         </div>
                     {% elif summary.bodyScanStatus === 'CLOSE_TO_LIMIT'  %}
-                        <div class="compliance-panel">
+                        <div class="compliance-panel" data-qa="close-to-limit">
                             <p class="govuk-!-margin-bottom-0 govuk-!-font-weight-bold">
                                 {{ arrival.firstName }} {{ arrival.lastName }} can only be scanned {{ summary.numberOfBodyScansRemaining }} more times this year
                             </p>

--- a/server/views/partials/expectedArrivalCardMacro.njk
+++ b/server/views/partials/expectedArrivalCardMacro.njk
@@ -60,7 +60,7 @@
                     <h2 class="app-card__title" data-qa="{{ moveType }}-title-{{ loopIndex }}">
                         {% if user.isReceptionUser %}
                             <a
-                                href="/confirm-arrival/choose-prisoner/{{ arrival.id }}"
+                                href="/confirm-arrival/choose-prisoner/{{ arrival.id }}/summary"
                                 class="govuk-link govuk-link--no-visited-state"
                                 data-qa="confirm-arrival">
                                 {{ arrival.lastName }}, {{ arrival.firstName }}</a>


### PR DESCRIPTION
Feature: when user clicks on a prisoner's name in the arrival list then one of two possible summary pages are displayed before the journey resumes to the original result set page. 

court returns, single matches  -> summaryWithRecord
multi-match, no-match, no ids ->  summaryMoveOnly
