### PR TITLE
DCS 2079 wpip UI prevent arrival reconfirmation v2

### DIFF
--- a/server/data/lockManager.test.ts
+++ b/server/data/lockManager.test.ts
@@ -3,6 +3,7 @@ import { RedisClient } from './redisClient'
 
 const redisClient = {
   set: jest.fn(),
+  del: jest.fn(),
   connect: jest.fn(),
   isOpen: true,
 } as unknown as jest.Mocked<RedisClient>
@@ -52,6 +53,22 @@ describe('lockManager', () => {
       await lockManager.lock('some-lock-id', 10)
 
       expect(redisClient.connect).toHaveBeenCalledWith()
+    })
+
+    it('Can delete lock', async () => {
+      redisClient.del.mockResolvedValue(1)
+
+      const result = await lockManager.deleteLock('some-lock-id')
+
+      expect(result).toStrictEqual(true)
+    })
+
+    it('lock deletion not successful', async () => {
+      redisClient.del.mockResolvedValue(0)
+
+      const result = await lockManager.deleteLock('some-lock-id')
+
+      expect(result).toStrictEqual(false)
     })
   })
 })

--- a/server/data/lockManager.ts
+++ b/server/data/lockManager.ts
@@ -30,4 +30,10 @@ export default class LockManager {
     const result = await this.client.get(`${this.prefix}${moveId}`)
     return Boolean(result)
   }
+
+  public async deleteLock(moveId: string): Promise<boolean> {
+    await this.ensureConnected()
+    const result = await this.client.del(`${this.prefix}${moveId}`)
+    return Boolean(result)
+  }
 }

--- a/server/middleware/backTrackPreventionMiddleware.test.ts
+++ b/server/middleware/backTrackPreventionMiddleware.test.ts
@@ -33,6 +33,14 @@ describe('caseloadCheck', () => {
         expect(next).not.toHaveBeenCalled()
         expect(res.redirect).toHaveBeenCalledWith('/some-where')
       })
+
+      test('does not set lock for unexpected-arrival', async () => {
+        req.params.id = 'unexpected-arrival'
+        await setLock(lockManager, '/some-where')(req, res, next)
+
+        expect(lockManager.lock).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith()
+      })
     })
 
     describe('isLocked', () => {

--- a/server/middleware/backTrackPreventionMiddleware.ts
+++ b/server/middleware/backTrackPreventionMiddleware.ts
@@ -4,15 +4,17 @@ import type LockManager from '../data/lockManager'
 
 export function setLock(lockManager: LockManager, location: string): RequestHandler {
   return async (req, res, next) => {
-    const { id: moveId } = req.params
+    const { id } = req.params
 
-    const lockSuccessful = await lockManager.lock(moveId, 30)
+    if (id !== 'unexpected-arrival') {
+      const lockSuccessful = await lockManager.lock(id, 30)
 
-    if (!lockSuccessful) {
-      logger.warn(`Unable to set lock - double click? redirecting to: ${location}`)
-      return res.redirect(location)
+      if (!lockSuccessful) {
+        logger.warn(`Unable to set lock - double click? redirecting to: ${location}`)
+        return res.redirect(location)
+      }
+      logger.info(`Double-click prevention lock set for id: ${id}`)
     }
-    logger.info(`Double-click prevention lock set for moveId: ${moveId}`)
     return next()
   }
 }

--- a/server/routes/bookedtoday/arrivals/confirmArrival/checkAnswersController.test.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/checkAnswersController.test.ts
@@ -102,6 +102,18 @@ describe('/checkAnswers', () => {
         .expect('Location', '/feature-not-available')
     })
 
+    it('should delete lock when redirecting to /feature-not-available', () => {
+      expectedArrivalsService.confirmArrival.mockResolvedValue(null)
+
+      return request(app)
+        .post(`/prisoners/${arrivalId}/check-answers`)
+        .expect(() => {
+          expect(lockManager.deleteLock).toHaveBeenCalledWith(arrivalId)
+        })
+        .expect(302)
+        .expect('Location', '/feature-not-available')
+    })
+
     it('should redirect to authentication error page for non reception users', () => {
       app = appWithAllRoutes({ services: { expectedArrivalsService }, roles: [] })
       return request(app).post(`/prisoners/${arrivalId}/check-answers`).expect(302).expect('Location', '/autherror')

--- a/server/routes/bookedtoday/arrivals/confirmArrival/index.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/index.ts
@@ -30,7 +30,8 @@ export default function routes(services: Services): Router {
 
   const checkAnswersController = new CheckAnswersController(
     services.expectedArrivalsService,
-    services.imprisonmentStatusesService
+    services.imprisonmentStatusesService,
+    services.lockManager
   )
 
   const setLock = backTrackPrevention.setLock(services.lockManager, '/confirm-arrival/choose-prisoner')


### PR DESCRIPTION
This v2 is as a result of issues found following peer testing. please refer to Charan's notes of 18/4 in the jira ticket.

There are two changes in this PR
1. In the unexpected-arrivals journey we don't want the double booking error page to be shown. 
The functionality has been achieved in the backtracking prevention middleware which only sets the lock if the 'id' in the url is not 'unexpected-arrival' 

2. In the standard expected arrival journey, if the user attempts to backtrack from 'Feature not available' page then we do not want to display the 'This person is being booked in' page.
This functionality has been achieved by calling the deleteLock function in the post to checkAnswersController if the application did not successfully confirm the arrival. (note: the rendering of the 'This person is being booked in' page is determined by the checkIsLocked middleware which looks for a set lock)