### PR TITLE
DCS-2230 hide any reference to body scans for Styal prison

### DIFF
--- a/server/views/pages/bookedtoday/summaryWithRecord.njk
+++ b/server/views/pages/bookedtoday/summaryWithRecord.njk
@@ -96,16 +96,18 @@
                             </p>
                         </div>
                     {% endif %}
-                    {{ summaryCard({
-                        classes: "govuk-!-margin-bottom-6",
-                        titleText: "X-ray body scan",
-                        rows: [
-                            {
-                                key: {  text: "Total number of scans", caption: "Since 1 January " + generateCurrentYear() },
-                                value:  { text: summary.numberOfBodyScans }
-                            }
-                        ]
-                    }) }}
+                    {% if user.activeCaseLoadId !== 'STI' %}
+                        {{ summaryCard({
+                            classes: "govuk-!-margin-bottom-6",
+                            titleText: "X-ray body scan",
+                            rows: [
+                                {
+                                    key: {  text: "Total number of scans", caption: "Since 1 January " + generateCurrentYear() },
+                                    value:  { text: summary.numberOfBodyScans }
+                                }
+                            ]
+                        }) }}
+                    {% endif %}
                 </div>
 
                 <div class='govuk-grid-column-one-third'>

--- a/server/views/pages/home.njk
+++ b/server/views/pages/home.njk
@@ -44,13 +44,23 @@
                 <h2 class="govuk-heading-m govuk-!-margin-top-7">Manage recent arrivals</h2>
                     <ul class="govuk-grid-row card-group">
                             <li class="govuk-grid-column-one-third card-group__item">
-                                {{ card({
-                                    "href": '/recent-arrivals',
-                                    "clickable": "true",
-                                    "heading": 'Recent arrivals',
-                                    "description": 'Record a body scan and add a case note for prisoners who have arrived within the last 3 days.',
-                                    "data-qa": "recent-arrivals"
-                                }) }}
+                                {% if user.activeCaseLoadId == 'STI' %}
+                                    {{ card({
+                                        "href": '/recent-arrivals',
+                                        "clickable": "true",
+                                        "heading": 'Recent arrivals',
+                                        "description": 'Manage reception tasks for prisoners who have arrived within the last 3 days.',
+                                        "data-qa": "recent-arrivals"
+                                    }) }}
+                                {% else %}
+                                    {{ card({
+                                        "href": '/recent-arrivals',
+                                        "clickable": "true",
+                                        "heading": 'Recent arrivals',
+                                        "description": 'Record a body scan and add a case note for prisoners who have arrived within the last 3 days.',
+                                        "data-qa": "recent-arrivals"
+                                    }) }}
+                                {% endif %}
                             </li>
                     </ul>
             {% endif %}

--- a/server/views/pages/recentArrivals/recentArrivalsSummary.njk
+++ b/server/views/pages/recentArrivals/recentArrivalsSummary.njk
@@ -90,19 +90,21 @@
                             </p>
                         </div>
                     {% endif %}
-                    {{ summaryCard({
-                        classes: "govuk-!-margin-bottom-6",
-                        titleText: "X-ray body scan",
-                        action: { href: "/prisoners/" + arrival.prisonNumber + "/record-body-scan", 
-                                  text: "Record an X-ray body scan", 
-                                  attributes: { 'data-qa': 'record-body-scan' } },
-                        rows: [
-                            {
-                                key: {  text: "Total number of scans", caption: "Since 1 January " + generateCurrentYear() },
-                                value:  { text: arrival.numberOfBodyScans }
-                            }
-                        ]
-                    }) }}
+                    {% if user.activeCaseLoadId !== 'STI' %}
+                        {{ summaryCard({
+                            classes: "govuk-!-margin-bottom-6",
+                            titleText: "X-ray body scan",
+                            action: { href: "/prisoners/" + arrival.prisonNumber + "/record-body-scan", 
+                                    text: "Record an X-ray body scan", 
+                                    attributes: { 'data-qa': 'record-body-scan' } },
+                            rows: [
+                                {
+                                    key: {  text: "Total number of scans", caption: "Since 1 January " + generateCurrentYear() },
+                                    value:  { text: arrival.numberOfBodyScans }
+                                }
+                            ]
+                        }) }}
+                    {% endif %}
                 </div>
 
                 <div class='govuk-grid-column-one-third'>


### PR DESCRIPTION
This is a a quick turn-around temp fix while we decide whether we want to hide body scan using user's current caseload or whether to use prisoner gender

The code changes in the PR have used current caseload