### PR TITLE
DCS-2145 send username to backend for some calls

### DIFF
--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.test.ts
@@ -46,7 +46,7 @@ describe('possible records found', () => {
       return request(app)
         .get(`/prisoners/${arrival.id}/possible-records-found`)
         .expect(() => {
-          expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith(arrival.id)
+          expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('user1', arrival.id)
         })
     })
 

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFoundController.ts
@@ -8,8 +8,9 @@ export default class MultipleExistingRecordsFoundController {
   public view(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { id } = req.params
+      const { username } = req.user
 
-      const arrival = await this.expectedArrivalsService.getArrival(id)
+      const arrival = await this.expectedArrivalsService.getArrival(username, id)
 
       return res.render('pages/bookedtoday/arrivals/autoMatchingRecords/multipleMatchingRecordsFound.njk', {
         arrival: {

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/noMatchingRecordsFoundController.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/noMatchingRecordsFoundController.ts
@@ -7,7 +7,8 @@ export default class NoMatchingRecordsFoundController {
   public view(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
-      const data = await this.expectedArrivalsService.getArrival(id)
+      const { username } = req.user
+      const data = await this.expectedArrivalsService.getArrival(username, id)
 
       return res.render('pages/bookedtoday/arrivals/autoMatchingRecords/noMatchingRecordsFound.njk', { data })
     }

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.test.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.test.ts
@@ -49,7 +49,7 @@ describe('GET /view', () => {
       .get('/prisoners/12345-67890/record-found')
       .expect('Content-Type', 'text/html; charset=utf-8')
       .expect(res => {
-        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('12345-67890')
+        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('user1', '12345-67890')
       })
   })
 

--- a/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.ts
+++ b/server/routes/bookedtoday/arrivals/autoMatchingRecords/singleMatchingRecordFoundController.ts
@@ -9,7 +9,8 @@ export default class SingleMatchingRecordFoundController {
   public view(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
-      const arrival = await this.expectedArrivalsService.getArrival(id)
+      const { username } = req.user
+      const arrival = await this.expectedArrivalsService.getArrival(username, id)
 
       const match = arrival.potentialMatches[0]
       State.newArrival.set(res, {

--- a/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.test.ts
@@ -62,7 +62,7 @@ describe('checkCourtReturnController', () => {
         .get('/prisoners/12345-67890/check-court-return')
         .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(() => {
-          expect(expectedArrivalsService.getPrisonerDetailsForArrival).toHaveBeenCalledWith('12345-67890')
+          expect(expectedArrivalsService.getPrisonerDetailsForArrival).toHaveBeenCalledWith('user1', '12345-67890')
         })
     })
 

--- a/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/checkCourtReturnController.ts
@@ -10,8 +10,10 @@ export default class CheckCourtReturnController {
   public checkCourtReturn(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
-      const data = await this.expectedArrivalsService.getPrisonerDetailsForArrival(id)
-      const prisonerEscortRecord = await this.expectedArrivalsService.getArrival(id)
+      const { username } = req.user
+
+      const data = await this.expectedArrivalsService.getPrisonerDetailsForArrival(username, id)
+      const prisonerEscortRecord = await this.expectedArrivalsService.getArrival(username, id)
       return res.render('pages/bookedtoday/arrivals/courtreturns/checkCourtReturn.njk', {
         data,
         id,
@@ -25,8 +27,8 @@ export default class CheckCourtReturnController {
       const { id } = req.params
       const { username } = req.user
       const { activeCaseLoadId } = res.locals.user
-      const arrival = await this.expectedArrivalsService.getArrival(id)
-      const data = await this.expectedArrivalsService.getPrisonerDetailsForArrival(id)
+      const arrival = await this.expectedArrivalsService.getArrival(username, id)
+      const data = await this.expectedArrivalsService.getPrisonerDetailsForArrival(username, id)
 
       const arrivalResponse = await this.expectedArrivalsService.confirmCourtReturn(
         username,

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.test.ts
@@ -52,7 +52,7 @@ describe('GET /review-per-details', () => {
       .get('/prisoners/12345-67890/review-per-details')
       .expect('Content-Type', 'text/html; charset=utf-8')
       .expect(res => {
-        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('12345-67890')
+        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('user1', '12345-67890')
       })
   })
 

--- a/server/routes/bookedtoday/arrivals/reviewDetailsController.ts
+++ b/server/routes/bookedtoday/arrivals/reviewDetailsController.ts
@@ -7,7 +7,9 @@ export default class ReviewDetailsController {
   public constructor(private readonly expectedArrivalsService: ExpectedArrivalsService) {}
 
   private async loadData(id: string, req: Request, res: Response): Promise<NewArrival> {
-    const arrival = await this.expectedArrivalsService.getArrival(id)
+    const { username } = req.user
+
+    const arrival = await this.expectedArrivalsService.getArrival(username, id)
 
     const data = {
       firstName: convertToTitleCase(arrival.firstName),

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.test.ts
@@ -77,7 +77,7 @@ describe('GET /search-for-existing-record', () => {
       .get('/prisoners/12345-67890/search-for-existing-record')
       .expect('Content-Type', 'text/html; charset=utf-8')
       .expect(() => {
-        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('12345-67890')
+        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('user1', '12345-67890')
       })
   })
 

--- a/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.ts
+++ b/server/routes/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecordController.ts
@@ -5,8 +5,8 @@ import { SearchDetails, State } from '../../state'
 export default class SearchForExistingRecordController {
   public constructor(private readonly expectedArrivalsService: ExpectedArrivalsService) {}
 
-  private async loadData(id: string, res: Response): Promise<SearchDetails> {
-    const arrival = await this.expectedArrivalsService.getArrival(id)
+  private async loadData(username: string, id: string, res: Response): Promise<SearchDetails> {
+    const arrival = await this.expectedArrivalsService.getArrival(username, id)
 
     const data = {
       firstName: arrival.firstName,
@@ -32,8 +32,9 @@ export default class SearchForExistingRecordController {
   public showSearch(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
+      const { username } = req.user
 
-      const data = State.searchDetails.get(req) || (await this.loadData(id, res))
+      const data = State.searchDetails.get(req) || (await this.loadData(username, id, res))
 
       res.render('pages/bookedtoday/arrivals/searchforexisting/search/searchForExistingRecord.njk', {
         data: { ...data, id },

--- a/server/routes/bookedtoday/choosePrisonerController.test.ts
+++ b/server/routes/bookedtoday/choosePrisonerController.test.ts
@@ -90,7 +90,7 @@ describe('GET /confirm-arrival/choose-prisoner', () => {
       .get('/confirm-arrival/choose-prisoner')
       .expect('Content-Type', 'text/html; charset=utf-8')
       .expect(res => {
-        expect(expectedArrivalsService.getArrivalsForToday).toHaveBeenCalledWith(user.activeCaseLoadId)
+        expect(expectedArrivalsService.getArrivalsForToday).toHaveBeenCalledWith('user1', user.activeCaseLoadId)
       })
   })
 
@@ -214,7 +214,7 @@ describe('GET /confirm-arrival/choose-prisoner/:id', () => {
     return request(app)
       .get('/confirm-arrival/choose-prisoner/aaa-111-222')
       .expect(res => {
-        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('aaa-111-222')
+        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('user1', 'aaa-111-222')
       })
   })
 

--- a/server/routes/bookedtoday/choosePrisonerController.ts
+++ b/server/routes/bookedtoday/choosePrisonerController.ts
@@ -9,7 +9,8 @@ export default class ChoosePrisonerController {
   public view(): RequestHandler {
     return async (req, res) => {
       const { activeCaseLoadId } = res.locals.user
-      const expectedArrivals = await this.expectedArrivalsService.getArrivalsForToday(activeCaseLoadId)
+      const { username } = req.user
+      const expectedArrivals = await this.expectedArrivalsService.getArrivalsForToday(username, activeCaseLoadId)
       return res.render('pages/bookedtoday/choosePrisoner.njk', {
         expectedArrivals,
       })
@@ -19,9 +20,10 @@ export default class ChoosePrisonerController {
   public redirectToConfirm(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
+      const { username } = req.user
       State.searchDetails.clear(res)
       State.newArrival.clear(res)
-      const arrival = await this.expectedArrivalsService.getArrival(id)
+      const arrival = await this.expectedArrivalsService.getArrival(username, id)
 
       switch (arrival.matchType) {
         case MatchType.INSUFFICIENT_INFO:

--- a/server/routes/bookedtoday/summaryController.test.ts
+++ b/server/routes/bookedtoday/summaryController.test.ts
@@ -104,7 +104,7 @@ describe('GET /confirm-arrival/choose-prisoner/:moveId/summary', () => {
       return request(app)
         .get('/confirm-arrival/choose-prisoner/aaa-111-222/summary')
         .expect(res => {
-          expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('aaa-111-222')
+          expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('user1', 'aaa-111-222')
         })
     })
 

--- a/server/routes/bookedtoday/summaryController.ts
+++ b/server/routes/bookedtoday/summaryController.ts
@@ -8,8 +8,9 @@ export default class SummaryController {
   public redirectToSummary(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
+      const { username } = req.user
 
-      const arrival = await this.expectedArrivalsService.getArrival(id)
+      const arrival = await this.expectedArrivalsService.getArrival(username, id)
       switch (arrival.matchType) {
         case MatchType.COURT_RETURN:
         case MatchType.SINGLE_MATCH:

--- a/server/routes/bookedtoday/summaryMoveOnlyController.test.ts
+++ b/server/routes/bookedtoday/summaryMoveOnlyController.test.ts
@@ -40,7 +40,7 @@ describe('GET /prisoner/:id/summary-move-only', () => {
     return request(app)
       .get('/prisoners/1111-1111-1111-1111/summary-move-only')
       .expect(res => {
-        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('1111-1111-1111-1111')
+        expect(expectedArrivalsService.getArrival).toHaveBeenCalledWith('user1', '1111-1111-1111-1111')
       })
   })
 

--- a/server/routes/bookedtoday/summaryMoveOnlyController.ts
+++ b/server/routes/bookedtoday/summaryMoveOnlyController.ts
@@ -7,7 +7,8 @@ export default class SummaryMoveOnlyController {
   public view(): RequestHandler {
     return async (req, res) => {
       const { id } = req.params
-      const arrival = await this.expectedArrivalsService.getArrival(id)
+      const { username } = req.user
+      const arrival = await this.expectedArrivalsService.getArrival(username, id)
       return res.render('pages/bookedtoday/summaryMoveOnly.njk', { arrival })
     }
   }

--- a/server/routes/bookedtoday/summaryWithRecordController.test.ts
+++ b/server/routes/bookedtoday/summaryWithRecordController.test.ts
@@ -41,7 +41,7 @@ describe('GET /prisoner/:id/summary-with-record', () => {
     return request(app)
       .get('/prisoners/1111-1111-1111-1111/summary-with-record')
       .expect(res => {
-        expect(expectedArrivalsService.getArrivalAndSummaryDetails).toHaveBeenCalledWith('1111-1111-1111-1111')
+        expect(expectedArrivalsService.getArrivalAndSummaryDetails).toHaveBeenCalledWith('user1', '1111-1111-1111-1111')
       })
   })
 

--- a/server/routes/bookedtoday/summaryWithRecordController.ts
+++ b/server/routes/bookedtoday/summaryWithRecordController.ts
@@ -9,8 +9,9 @@ export default class SummaryWithRecordController {
     return async (req, res) => {
       const { id } = req.params
       const { roles } = res.locals.user
+      const { username } = req.user
       const enableDpsLink = roles.includes(Role.PRISON_RECEPTION) && roles.includes(Role.ROLE_INACTIVE_BOOKINGS)
-      const data = await this.expectedArrivalsService.getArrivalAndSummaryDetails(id)
+      const data = await this.expectedArrivalsService.getArrivalAndSummaryDetails(username, id)
       return res.render('pages/bookedtoday/summaryWithRecord.njk', { ...data, enableDpsLink })
     }
   }

--- a/server/services/expectedArrivalsService.test.ts
+++ b/server/services/expectedArrivalsService.test.ts
@@ -24,6 +24,7 @@ import { MatchType } from './matchTypeDecorator'
 jest.mock('./raiseAnalyticsEvent')
 
 const token = 'some token'
+const username = 'user1'
 
 describe('Expected arrivals service', () => {
   const welcomeClient = createMockWelcomeClient()
@@ -87,7 +88,7 @@ describe('Expected arrivals service', () => {
 
     it('Retrieves expected arrivals sorted alphabetically by name', async () => {
       const today = moment()
-      const result = await service.getArrivalsForToday(res.locals.user.activeCaseLoadId, () => today)
+      const result = await service.getArrivalsForToday(username, res.locals.user.activeCaseLoadId, () => today)
 
       const arrival = (a: Parameters<typeof createArrival>[0]) => withMatchType(withBodyScanStatus(createArrival(a)))
 
@@ -112,7 +113,7 @@ describe('Expected arrivals service', () => {
     })
 
     it('WelcomeClientFactory is called with a token', async () => {
-      await service.getArrivalsForToday(res.locals.user.activeCaseLoadId)
+      await service.getArrivalsForToday(username, res.locals.user.activeCaseLoadId)
 
       expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
       expect(WelcomeClientFactory).toBeCalledWith(token)
@@ -216,7 +217,7 @@ describe('Expected arrivals service', () => {
 
   describe('getArrival', () => {
     it('Calls upstream service correctly', async () => {
-      await service.getArrival('12345-67890')
+      await service.getArrival(username, '12345-67890')
 
       expect(WelcomeClientFactory).toBeCalledWith(token)
       expect(welcomeClient.getArrival).toBeCalledWith('12345-67890')
@@ -226,7 +227,7 @@ describe('Expected arrivals service', () => {
       const arrival = createArrival()
       welcomeClient.getArrival.mockResolvedValue(arrival)
 
-      const result = await service.getArrival('12345-67890')
+      const result = await service.getArrival(username, '12345-67890')
 
       expect(result).toStrictEqual({ ...arrival, matchType: MatchType.SINGLE_MATCH })
     })
@@ -236,7 +237,7 @@ describe('Expected arrivals service', () => {
     it('Calls upstream service correctly', async () => {
       const arrival = createArrival()
       welcomeClient.getArrival.mockResolvedValue(arrival)
-      const result = await service.getPrisonerDetailsForArrival('12345-67890')
+      const result = await service.getPrisonerDetailsForArrival(username, '12345-67890')
 
       expect(WelcomeClientFactory).toBeCalledWith(token)
       expect(welcomeClient.getArrival).toBeCalledWith('12345-67890')
@@ -252,7 +253,7 @@ describe('Expected arrivals service', () => {
       welcomeClient.getArrival.mockResolvedValue(arrival)
       welcomeClient.getPrisonerDetails.mockResolvedValue(createPrisonerDetails())
 
-      const result = await service.getArrivalAndSummaryDetails('12345-67890')
+      const result = await service.getArrivalAndSummaryDetails(username, '12345-67890')
 
       expect(WelcomeClientFactory).toBeCalledWith(token)
       expect(welcomeClient.getArrival).toBeCalledWith('12345-67890')
@@ -271,7 +272,6 @@ describe('Expected arrivals service', () => {
   })
 
   describe('confirm expected arrival', () => {
-    const username = 'Bob'
     const newArrival: NewArrival = createNewArrival()
 
     beforeEach(() => {
@@ -326,7 +326,6 @@ describe('Expected arrivals service', () => {
   })
 
   describe('confirm unexpected arrival', () => {
-    const username = 'Bob'
     const newArrival: NewArrival = createNewArrival({ expected: false })
 
     it('Calls hmppsAuth correctly', async () => {
@@ -378,9 +377,9 @@ describe('Expected arrivals service', () => {
 
   describe('confirmCourtReturn', () => {
     it('Calls upstream services correctly', async () => {
-      await service.confirmCourtReturn('user1', '12345-67890', 'MDI', 'A1234AA')
+      await service.confirmCourtReturn(username, '12345-67890', 'MDI', 'A1234AA')
 
-      expect(hmppsAuthClient.getSystemClientToken).toBeCalledWith('user1')
+      expect(hmppsAuthClient.getSystemClientToken).toBeCalledWith(username)
       expect(WelcomeClientFactory).toBeCalledWith(token)
       expect(welcomeClient.confirmCourtReturn).toBeCalledWith('12345-67890', 'MDI', 'A1234AA')
     })
@@ -388,7 +387,7 @@ describe('Expected arrivals service', () => {
     it('Should return null', async () => {
       welcomeClient.confirmCourtReturn.mockResolvedValue(null)
 
-      const result = await service.confirmCourtReturn('user1', '12345-67890', 'MDI', 'A1234AA')
+      const result = await service.confirmCourtReturn(username, '12345-67890', 'MDI', 'A1234AA')
       expect(result).toBe(null)
     })
   })


### PR DESCRIPTION
The BASM service would like to know which users access its service. This will be achieved by adding the 'X-current-user' header to calls made by wpip-api to BASM. However the user details originate in wpip-ui and hence they need to be passed from wpip-ui to wpip-api and onwards to BASM.
There are 2 specific wpip-api endpoints that need the username:- 

1. /arrivals/{arrivalId}
2. /prisons/{prisonId}/arrivals

So this ticket is to add the username to wpip-ui functions that result in hitting those 2 endpoints. 