### PR TITLE
MAP-302 add missing target for scripts in helmet

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -25,6 +25,7 @@ export default function setUpWebSecurity(): Router {
   // This ensures only scripts we trust are loaded, and not anything injected into the
   // page by an attacker.
   const scriptSrc = [
+    "'self'",
     '*.googletagmanager.com',
     '*.google-analytics.com',
     (req: IncomingMessage, res: Response) => `'nonce-${res.locals.cspNonce}'`,


### PR DESCRIPTION
Requires scriptSrc to include 'self'  - missed in previous PR
was preventing back link from working