### PR TITLE
MAP-828 fix CVE vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "jwt-decode": "^3.1.2",
         "moment": "^2.29.4",
         "nocache": "^3.0.4",
-        "notifications-node-client": "^7.0.6",
+        "notifications-node-client": "^8.0.0",
         "nunjucks": "^3.2.4",
         "passport": "^0.6.0",
         "passport-oauth2": "^1.7.0",
@@ -2891,11 +2891,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -5645,9 +5645,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -9071,9 +9071,9 @@
       }
     },
     "node_modules/notifications-node-client": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-7.0.6.tgz",
-      "integrity": "sha512-qo6eZMGdyaQnj/bkOnPb/d0a0sHIjiBzXlmICLPXYSD4pB3LYa537OhuZGuaFcSnkrM4NzbQhbQHAYX1NnbQgw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.0.0.tgz",
+      "integrity": "sha512-65BxorFYVFOpJ9c2lud/4Ju+Bfn3L/vkih+FuzMhBw1wcOPjwgu4doVH6xO91fHYiAi/0uIx0Mc+NorXeANMHw==",
       "dependencies": {
         "axios": "^1.6.1",
         "jsonwebtoken": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "jwt-decode": "^3.1.2",
     "moment": "^2.29.4",
     "nocache": "^3.0.4",
-    "notifications-node-client": "^7.0.6",
+    "notifications-node-client": "^8.0.0",
     "nunjucks": "^3.2.4",
     "passport": "^0.6.0",
     "passport-oauth2": "^1.7.0",
@@ -185,6 +185,9 @@
     },
     "jest-html-reporter": {
       "@babel/traverse": "7.23.2"
+    },
+    "notifications-node-client": {
+      "axios": "1.6.7"
     }
   }
 }


### PR DESCRIPTION
'follow-redirects' has a CVE vulnerability.  
It is a 2nd level dependency of notifications-node-client. Updating notifications-node-client on it's own did not result in update of follow-redirect. So overrode  axios to 1.6.7 as this  uses follow-redirects

dependency tree: 
 notifications-node-client@8.0.0
               axios@1.6.7
                      follow-redirects@1.15.5
                     form-data@4.0.0 deduped
                      proxy-from-env@1.1.0

see https://www.npmjs.com/package/notifications-node-client?activeTab=dependencies