### PR TITLE
MAP-1560 google sheets limited to 1 year of data

### DIFF
--- a/jobs/eventsJob.ts
+++ b/jobs/eventsJob.ts
@@ -1,7 +1,5 @@
 // Require app insights before anything else to allow for instrumentation of bunyan
 import '../server/utils/azureAppInsights'
-
-import moment from 'moment'
 import { HmppsAuthClient, WelcomeClient, type RestClientBuilder } from '../server/data'
 import { InMemoryTokenStore } from '../server/data/tokenStore'
 import EventsRetriever from './eventsRetriever'
@@ -17,7 +15,7 @@ const retriever = new EventsRetriever(hmppsAuthClient, welcomeClientBuilder)
 const pusher = new EventsPusher(config.eventPublishing.serviceAccountKey, config.eventPublishing.spreadsheetId)
 
 const job = async () => {
-  const events = await retriever.retrieveEventsForDay(moment())
+  const events = await retriever.retrieveEventsForPastYear()
   await pusher.pushEvents(events)
 }
 

--- a/jobs/eventsPusher.ts
+++ b/jobs/eventsPusher.ts
@@ -39,15 +39,19 @@ export default class EventsPusher {
       logger.info(`EventsPusher: Finished. No events to push.`)
       return
     }
-    const firstRow = parseInt(events[0][0], 10)
-    const range = `A${firstRow + 1}`
+
+    await this.spreadsheets.values.clear({
+      spreadsheetId: this.spreadsheetId,
+      range: '2:384615',
+    })
+
     try {
       const result = await this.spreadsheets.values.batchUpdate({
         spreadsheetId: this.spreadsheetId,
         requestBody: {
           data: [
             {
-              range,
+              range: 'A2',
               values: events,
             },
           ],

--- a/jobs/eventsRetriever.test.ts
+++ b/jobs/eventsRetriever.test.ts
@@ -20,7 +20,8 @@ describe('test', () => {
       Readable.from('a,b,c\n1,2,3\n4,5,6').pipe(writable)
     })
 
-    const events = await eventsRetriever.retrieveEventsForDay(moment('2021-07-01 09:01:01'))
+    const dataStartDate = moment().subtract(1, 'years').startOf('day')
+    const events = await eventsRetriever.retrieveEventsForPastYear()
 
     expect(events).toStrictEqual([
       ['1', '2', '3'],
@@ -28,11 +29,8 @@ describe('test', () => {
     ])
 
     const call = welcomeClient.getEventsCSV.mock.calls[0]
-
-    expect(
-      moment({ year: 2021, month: 6, day: 1, hour: 0, minute: 0, seconds: 0, milliseconds: 0 }).isSame(call[1])
-    ).toBe(true)
-    expect(call[2]).toBe(1)
+    expect(dataStartDate.isSame(call[1])).toBe(true)
+    expect(call[2]).toBe(365)
   })
 
   it('Handles no events', async () => {
@@ -41,7 +39,7 @@ describe('test', () => {
       Readable.from('a,b,c\n').pipe(writable)
     })
 
-    const events = await eventsRetriever.retrieveEventsForDay(moment('2021-07-01'))
+    const events = await eventsRetriever.retrieveEventsForPastYear()
     expect(events).toStrictEqual([])
   })
 })

--- a/jobs/eventsRetriever.ts
+++ b/jobs/eventsRetriever.ts
@@ -1,4 +1,4 @@
-import type { Moment } from 'moment'
+import moment from 'moment'
 import { parse } from 'csv-parse'
 import logger from '../logger'
 
@@ -10,7 +10,7 @@ export default class EventsRetriever {
     private readonly welcomeClientBuilder: RestClientBuilder<WelcomeClient>
   ) {}
 
-  async retrieveEventsForDay(day: Moment): Promise<string[][]> {
+  async retrieveEventsForPastYear(): Promise<string[][]> {
     const token = await this.hmppsAuthClient.getSystemClientToken()
     const welcomeClient = this.welcomeClientBuilder(token)
     const parser = parse({
@@ -19,12 +19,14 @@ export default class EventsRetriever {
       from: 2,
     })
     const records: string[][] = []
-    welcomeClient.getEventsCSV(parser, day.startOf('day'), 1)
+    const dateOneYearAgo = moment().subtract(1, 'years').startOf('day')
+    welcomeClient.getEventsCSV(parser, dateOneYearAgo, 365)
+
     // eslint-disable-next-line no-restricted-syntax
     for await (const record of parser) {
       records.push(record)
     }
-    logger.info(`Retrieved ${records.length} events for ${day}`)
+    logger.info(`Retrieved ${records.length} events since ${dateOneYearAgo}`)
     return records
   }
 }


### PR DESCRIPTION
[MAP-1560](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-1560)

[This](https://mojdt.slack.com/archives/C03DBE9GNJE/p1724069540080749) cron job failing because the data being pushed to the google sheet was exceeding the sheet's limits. This is because new data is appended to existing data , which began in 2021. The change in this code is to replace rather than append data,  and limit it to a rolling 1 year back in time. 

[MAP-1560]: https://dsdmoj.atlassian.net/browse/MAP-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ