### PR TITLE
Map 1688 wpip UI user prison register to get prison data

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,6 +7,7 @@ import components from './integration_tests/mockApis/components'
 import auth from './integration_tests/mockApis/auth'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import welcome from './integration_tests/mockApis/welcome'
+import prisonRegister from './integration_tests/mockApis/prisonRegister'
 import bodyscan from './integration_tests/mockApis/bodyScan'
 
 export default defineConfig({
@@ -56,7 +57,6 @@ export default defineConfig({
         getTemporaryAbsenceConfirmationRequest: welcome.getTemporaryAbsenceConfirmationRequest,
         stubConfirmCourtReturn: welcome.stubConfirmCourtReturn,
         stubConfirmCourtReturnsError: welcome.stubConfirmCourtReturnsError,
-        stubPrison: welcome.stubPrison,
         stubPrisonerImage: welcome.stubPrisonerImage,
         stubMissingPrisonerImage: welcome.stubMissingPrisonerImage,
         stubCreateOffenderRecordAndBooking: ({ arrivalId, prisonNumber, location }) =>
@@ -72,6 +72,9 @@ export default defineConfig({
         getConfirmationRequest: welcome.getConfirmationRequest,
         getUnexpectedConfirmationRequest: welcome.getUnexpectedConfirmationRequest,
         getTransferConfirmationRequest: welcome.getTransferConfirmationRequest,
+
+        // prison register stubs
+        stubPrison: prisonRegister.stubPrison,
 
         // body-scan
         stubBodyScanApiPing: bodyscan.stubPing,

--- a/feature.env
+++ b/feature.env
@@ -3,6 +3,7 @@ HMPPS_AUTH_URL=http://localhost:9091/auth
 HMPPS_MANAGE_USERS_API_URL=http://localhost:9091
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 WELCOME_API_URL=http://localhost:9091/welcome
+PRISON_REGISTER_API_URL=http://localhost:9091/prison-register
 BODYSCAN_API_URL=http://localhost:9091/bodyscan
 COMPONENT_API_URL=http://localhost:9091/components
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,7 @@ generic-service:
     ENVIRONMENT_NAME: 'DEV'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     WELCOME_API_URL: 'https://welcome-api-dev.prison.service.justice.gov.uk'
+    PRISON_REGISTER_API_URL: 'https://prison-register-dev.hmpps.service.justice.gov.uk'
     # Body scan functionality is currently located in WPIP API
     COMPONENT_API_URL: 'https://frontend-components-dev.hmpps.service.justice.gov.uk'
     BODYSCAN_API_URL: 'https://welcome-api-dev.prison.service.justice.gov.uk'

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,7 @@ generic-service:
     ENVIRONMENT_NAME: 'PRE-PRODUCTION'
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     WELCOME_API_URL: "https://welcome-api-preprod.prison.service.justice.gov.uk"
+    PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     BODYSCAN_API_URL: "https://welcome-api-preprod.prison.service.justice.gov.uk"
     HMPPS_COOKIE_NAME: hmpps-session-preprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,7 @@ generic-service:
     ENVIRONMENT_NAME: ''
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     WELCOME_API_URL: "https://welcome-api.prison.service.justice.gov.uk"
+    PRISON_REGISTER_API_URL: "https://prison-register.hmpps.service.justice.gov.uk"
     COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
     BODYSCAN_API_URL: "https://welcome-api.prison.service.justice.gov.uk"
     HMPPS_COOKIE_NAME: hmpps-session-prod

--- a/integration_tests/mockApis/prisonRegister.ts
+++ b/integration_tests/mockApis/prisonRegister.ts
@@ -1,0 +1,32 @@
+import { SuperAgentRequest } from 'superagent'
+import { stubFor } from './wiremock'
+
+export default {
+  stubPing: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: '/prison-register/health/ping',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { status: 'UP' },
+      },
+    })
+  },
+
+  stubPrison: (activeCaseLoadId: string): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/prison-register/prisons/id/${activeCaseLoadId}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { prisonName: 'Moorland (HMP & YOI)' },
+      },
+    })
+  },
+}

--- a/server/@types/welcome/index.d.ts
+++ b/server/@types/welcome/index.d.ts
@@ -127,7 +127,7 @@ declare module 'welcome' {
       movementReasons: { description?: string; movementReasonCode: string }[]
     }
     Prison: {
-      description: string
+      prisonName: string
     }
     ArrivalResponse: {
       prisonNumber: string

--- a/server/config.ts
+++ b/server/config.ts
@@ -97,6 +97,14 @@ export default {
       },
       agent: DEFAULT_AGENT_CONFIG,
     },
+    prisonRegister: {
+      url: get('PRISON_REGISTER_API_URL', 'http://localhost:8100', requiredInProduction),
+      timeout: {
+        response: Number(get('PRISON_REGISTER_API_TIMEOUT_RESPONSE', 5000)),
+        deadline: Number(get('PRISON_REGISTER_API_TIMEOUT_DEADLINE', 5000)),
+      },
+      agent: DEFAULT_AGENT_CONFIG,
+    },
     frontendComponents: {
       url: get('COMPONENT_API_URL', 'http://localhost:8082', requiredInProduction),
       timeout: {

--- a/server/data/__testutils/mocks.ts
+++ b/server/data/__testutils/mocks.ts
@@ -1,8 +1,17 @@
-import { WelcomeClient, HmppsAuthClient, BodyScanClient, LockManager, FeComponentsClient } from '..'
+import {
+  WelcomeClient,
+  PrisonRegisterClient,
+  HmppsAuthClient,
+  BodyScanClient,
+  LockManager,
+  FeComponentsClient,
+} from '..'
 
 jest.mock('..')
 
 export const createMockWelcomeClient = () => new WelcomeClient(null) as jest.Mocked<WelcomeClient>
+
+export const createMockPrisonRegisterClient = () => new PrisonRegisterClient(null) as jest.Mocked<PrisonRegisterClient>
 
 export const createMockHmppsAuthClient = () => new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
 

--- a/server/data/__testutils/testObjects.ts
+++ b/server/data/__testutils/testObjects.ts
@@ -288,7 +288,7 @@ export const createNewArrival = ({
   expected,
 })
 
-export const createPrison = ({ description = 'Moorland (HMP & YOI)' } = {}): Prison => ({ description })
+export const createPrison = ({ prisonName = 'Moorland (HMP & YOI)' } = {}): Prison => ({ prisonName })
 
 export const createUserCaseLoad = ({
   caseLoadId = 'MDI',

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -8,6 +8,7 @@ import HmppsAuthClient from './hmppsAuthClient'
 import { createRedisClient } from './redisClient'
 import { RedisTokenStore } from './tokenStore'
 import WelcomeClient from './welcomeClient'
+import PrisonRegisterClient from './prisonRegisterClient'
 import BodyScanClient from './bodyScanClient'
 import FeComponentsClient from './feComponentsClient'
 import notifyClient from './notifyClient'
@@ -25,6 +26,10 @@ export const dataAccess = () => {
     notifyClient,
     hmppsAuthClient: new HmppsAuthClient(new RedisTokenStore(redisClient)),
     welcomeClientBuilder: ((token: string) => new WelcomeClient(token)) as RestClientBuilder<WelcomeClient>,
+
+    prisonRegisterClientBuilder: ((token: string) =>
+      new PrisonRegisterClient(token)) as RestClientBuilder<PrisonRegisterClient>,
+
     bodyScanClientBuilder: ((token: string) => new BodyScanClient(token)) as RestClientBuilder<BodyScanClient>,
     feComponentsClientBuilder: ((token: string) =>
       new FeComponentsClient(token)) as RestClientBuilder<FeComponentsClient>,
@@ -33,4 +38,12 @@ export const dataAccess = () => {
 }
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { WelcomeClient, BodyScanClient, HmppsAuthClient, RestClientBuilder, LockManager, FeComponentsClient }
+export {
+  WelcomeClient,
+  PrisonRegisterClient,
+  BodyScanClient,
+  HmppsAuthClient,
+  RestClientBuilder,
+  LockManager,
+  FeComponentsClient,
+}

--- a/server/data/prisonRegisterClient.test.ts
+++ b/server/data/prisonRegisterClient.test.ts
@@ -1,0 +1,43 @@
+import nock from 'nock'
+import type { Prison } from 'welcome'
+import PrisonRegisterClient from './prisonRegisterClient'
+import config from '../config'
+
+describe('prisonRegisterClient', () => {
+  let fakePrisonRegisterApi: nock.Scope
+  let prisonRegisterClient: PrisonRegisterClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.prisonRegister.url = 'http://localhost:8080'
+    fakePrisonRegisterApi = nock(config.apis.prisonRegister.url)
+    prisonRegisterClient = new PrisonRegisterClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('getPrison', () => {
+    const prison: Prison = {
+      prisonName: 'Moorland (HMP & YOI)',
+    }
+    const prisonId = 'MDI'
+
+    it('should return data from api', async () => {
+      fakePrisonRegisterApi
+        .get(`/prisons/id/${prisonId}`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, prison)
+
+      const output = await prisonRegisterClient.getPrison(prisonId)
+      expect(output).toEqual(prison)
+    })
+  })
+})

--- a/server/data/prisonRegisterClient.ts
+++ b/server/data/prisonRegisterClient.ts
@@ -1,0 +1,19 @@
+import type { Prison } from 'welcome'
+import config, { ApiConfig } from '../config'
+import RestClient from './restClient'
+import logger from '../../logger'
+
+export default class PrisonRegisterClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('prisonRegisterClient', config.apis.prisonRegister as ApiConfig, token)
+  }
+
+  async getPrison(prisonId: string): Promise<Prison> {
+    logger.info(`prisonRegisterApi: getPrison(${prisonId})`)
+    return this.restClient.get({
+      path: `/prisons/id/${prisonId}`,
+    }) as Promise<Prison>
+  }
+}

--- a/server/data/welcomeClient.test.ts
+++ b/server/data/welcomeClient.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import moment from 'moment'
-import type { Arrival, ConfirmArrivalDetail, Prison, TemporaryAbsence, UserCaseLoad } from 'welcome'
+import type { Arrival, ConfirmArrivalDetail, TemporaryAbsence, UserCaseLoad } from 'welcome'
 import WelcomeClient from './welcomeClient'
 import config from '../config'
 import {

--- a/server/data/welcomeClient.test.ts
+++ b/server/data/welcomeClient.test.ts
@@ -285,20 +285,6 @@ describe('welcomeClient', () => {
     })
   })
 
-  describe('getPrison', () => {
-    const prison: Prison = {
-      description: 'Moorland (HMP & YOI)',
-    }
-    const prisonId = 'MDI'
-
-    it('should return data from api', async () => {
-      fakeWelcomeApi.get(`/prison/${prisonId}`).matchHeader('authorization', `Bearer ${token}`).reply(200, prison)
-
-      const output = await welcomeClient.getPrison(prisonId)
-      expect(output).toEqual(prison)
-    })
-  })
-
   describe('confirmExpectedArrival', () => {
     const detail: ConfirmArrivalDetail = {
       firstName: 'Jim',

--- a/server/data/welcomeClient.ts
+++ b/server/data/welcomeClient.ts
@@ -146,13 +146,6 @@ export default class WelcomeClient {
     }) as Promise<Readable>
   }
 
-  async getPrison(prisonId: string): Promise<Prison> {
-    logger.info(`welcomeApi: getPrison(${prisonId})`)
-    return this.restClient.get({
-      path: `/prison/${prisonId}`,
-    }) as Promise<Prison>
-  }
-
   async confirmExpectedArrival(id: string, detail: ConfirmArrivalDetail): Promise<ArrivalResponse | null> {
     logger.info(`welcomeApi: confirmExpectedArrival(${id})`)
     try {

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -19,7 +19,7 @@ const userCaseLoads: UserCaseLoad[] = [
 
 userService.getUser = jest.fn().mockResolvedValue({})
 userService.getUserCaseLoads = jest.fn().mockResolvedValue(userCaseLoads)
-prisonService.getPrison = jest.fn().mockResolvedValue({ description: 'Moorland (HMP & YOI)' })
+prisonService.getPrison = jest.fn().mockResolvedValue({ prisonName: 'Moorland (HMP & YOI)' })
 
 describe('populateCurrentUser', () => {
   const req = {
@@ -44,7 +44,7 @@ describe('populateCurrentUser', () => {
   it('should store activeCaseLoad in response', async () => {
     const res = { locals: { user: {} } } as unknown as Response
     await populateCurrentUser(userService, prisonService)(req, res, next)
-    expect(res.locals.user.activeCaseLoad).toEqual({ description: 'Moorland (HMP & YOI)' })
+    expect(res.locals.user.activeCaseLoad).toEqual({ prisonName: 'Moorland (HMP & YOI)' })
   })
 
   it('should store userCaseloads in response', async () => {

--- a/server/routes/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRollController.test.ts
+++ b/server/routes/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRollController.test.ts
@@ -21,7 +21,7 @@ describe('confirmCourtReturnAddedToRollController', () => {
     })
 
     prisonService.getPrison.mockResolvedValue({
-      description: 'Moorland (HMP & YOI)',
+      prisonName: 'Moorland (HMP & YOI)',
     })
 
     config.confirmEnabled = true

--- a/server/routes/bookedtoday/transfers/confirmTransferAddedToRollController.test.ts
+++ b/server/routes/bookedtoday/transfers/confirmTransferAddedToRollController.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
   })
 
   prisonService.getPrison.mockResolvedValue({
-    description: 'Moorland (HMP & YOI)',
+    prisonName: 'Moorland (HMP & YOI)',
   })
 })
 

--- a/server/routes/feedback/feedbackController.test.ts
+++ b/server/routes/feedback/feedbackController.test.ts
@@ -24,7 +24,7 @@ describe('feedbackController', () => {
     })
 
     prisonService.getPrison.mockResolvedValue({
-      description: 'Moorland (HMP & YOI)',
+      prisonName: 'Moorland (HMP & YOI)',
     })
     flashProvider.mockReturnValue([])
   })

--- a/server/routes/feedback/feedbackFormController.ts
+++ b/server/routes/feedback/feedbackFormController.ts
@@ -28,12 +28,12 @@ export default class FeedbackController {
         return res.redirect(`/feedback`)
       }
 
-      const prison = await this.prisonService.getPrison(activeCaseLoadId)
+      const { prisonName } = await this.prisonService.getPrison(activeCaseLoadId)
 
       try {
         await this.notificationService.sendEmail({
           username,
-          prison: prison.description,
+          prison: prisonName,
           feedback,
           email: email || '(No email address provided)',
         })

--- a/server/routes/temporaryabsences/confirmTemporaryAbsenceAddedToRollController.test.ts
+++ b/server/routes/temporaryabsences/confirmTemporaryAbsenceAddedToRollController.test.ts
@@ -17,7 +17,7 @@ describe('confirmTemporaryAbsenceAddedToRollController', () => {
     })
 
     prisonService.getPrison.mockResolvedValue({
-      description: 'Moorland (HMP & YOI)',
+      prisonName: 'Moorland (HMP & YOI)',
     })
 
     config.confirmEnabled = true

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -16,6 +16,7 @@ export const services = () => {
   const {
     hmppsAuthClient,
     welcomeClientBuilder,
+    prisonRegisterClientBuilder,
     bodyScanClientBuilder,
     feComponentsClientBuilder,
     notifyClient,
@@ -43,7 +44,7 @@ export const services = () => {
   )
   const imprisonmentStatusesService = new ImprisonmentStatusesService(hmppsAuthClient, welcomeClientBuilder)
   const transfersService = new TransfersService(hmppsAuthClient, welcomeClientBuilder, bodyScanInfoDecorator)
-  const prisonService = new PrisonService(hmppsAuthClient, welcomeClientBuilder)
+  const prisonService = new PrisonService(hmppsAuthClient, prisonRegisterClientBuilder)
   const feComponentsService = new FeComponentsService(feComponentsClientBuilder)
 
   return {

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -1,20 +1,20 @@
 import PrisonService from './prisonService'
 import { createPrison } from '../data/__testutils/testObjects'
-import { createMockHmppsAuthClient, createMockWelcomeClient } from '../data/__testutils/mocks'
+import { createMockHmppsAuthClient, createMockPrisonRegisterClient } from '../data/__testutils/mocks'
 
 const token = 'some token'
 
 describe('Expected arrivals service', () => {
-  const welcomeClient = createMockWelcomeClient()
+  const prisonRegisterClient = createMockPrisonRegisterClient()
   const hmppsAuthClient = createMockHmppsAuthClient()
   let service: PrisonService
 
-  const WelcomeClientFactory = jest.fn()
+  const PrisonRegisterClientFactory = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    WelcomeClientFactory.mockReturnValue(welcomeClient)
-    service = new PrisonService(hmppsAuthClient, WelcomeClientFactory)
+    PrisonRegisterClientFactory.mockReturnValue(prisonRegisterClient)
+    service = new PrisonService(hmppsAuthClient, PrisonRegisterClientFactory)
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(token)
   })
 
@@ -22,14 +22,14 @@ describe('Expected arrivals service', () => {
     const prison = createPrison()
 
     beforeEach(() => {
-      welcomeClient.getPrison.mockResolvedValue(prison)
+      prisonRegisterClient.getPrison.mockResolvedValue(prison)
     })
 
     it('Calls upstream service correctly', async () => {
       await service.getPrison('MDI')
 
-      expect(WelcomeClientFactory).toBeCalledWith(token)
-      expect(welcomeClient.getPrison).toBeCalledWith('MDI')
+      expect(PrisonRegisterClientFactory).toBeCalledWith(token)
+      expect(prisonRegisterClient.getPrison).toBeCalledWith('MDI')
     })
 
     it('Should return correct data', async () => {

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,14 +1,14 @@
 import type { Prison } from 'welcome'
-import type { RestClientBuilder, WelcomeClient, HmppsAuthClient } from '../data'
+import type { RestClientBuilder, PrisonRegisterClient, HmppsAuthClient } from '../data'
 
 export default class PrisonService {
   constructor(
     private readonly hmppsAuthClient: HmppsAuthClient,
-    private readonly welcomeClientFactory: RestClientBuilder<WelcomeClient>
+    private readonly prisonRegisterClientFactory: RestClientBuilder<PrisonRegisterClient>
   ) {}
 
   public async getPrison(activeCaseLoadId: string): Promise<Prison> {
     const token = await this.hmppsAuthClient.getSystemClientToken()
-    return this.welcomeClientFactory(token).getPrison(activeCaseLoadId)
+    return this.prisonRegisterClientFactory(token).getPrison(activeCaseLoadId)
   }
 }

--- a/server/views/pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll.njk
+++ b/server/views/pages/bookedtoday/arrivals/confirmArrival/confirmAddedToRoll.njk
@@ -11,7 +11,7 @@
                     'data-qa': 'confirmation-banner'
                 }
             }) }}
-            <p data-qa="confirmation-paragraph">{{ firstName }} {{ lastName }} is now part of the {{ prison.description }} establishment roll.</p>
+            <p data-qa="confirmation-paragraph">{{ firstName }} {{ lastName }} is now part of the {{ prison.prisonName }} establishment roll.</p>
             <p data-qa="location-paragraph">Their location is {{ location }}.</p>
             <h2 class="govuk-heading-m">Add more information about this person</h2>
             <p>

--- a/server/views/pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll.njk
+++ b/server/views/pages/bookedtoday/arrivals/courtreturns/confirmCourtReturnAddedToRoll.njk
@@ -6,7 +6,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
-                titleText: firstName + " " + lastName + " " + "has returned to " + prison.description,
+                titleText: firstName + " " + lastName + " " + "has returned to " + prison.prisonName,
                 html: "Prison number<br><strong>" + prisonNumber | escape + "</strong>",
                 attributes: {
                     'data-qa': 'confirmation-banner'

--- a/server/views/pages/bookedtoday/transfers/confirmTransferAddedToRoll.njk
+++ b/server/views/pages/bookedtoday/transfers/confirmTransferAddedToRoll.njk
@@ -12,7 +12,7 @@
                     'data-qa': 'confirmation-banner'
                 }
             }) }}
-            <p data-qa="confirmation-paragraph">{{ firstName }} {{ lastName }} is now part of the {{ prison.description }} establishment roll.</p>
+            <p data-qa="confirmation-paragraph">{{ firstName }} {{ lastName }} is now part of the {{ prison.prisonName }} establishment roll.</p>
             <p data-qa="location-paragraph">Their location is {{ location }}.</p>
             <h2 class="govuk-heading-m">Add more information about this person</h2>
             <p>

--- a/server/views/pages/temporaryabsences/confirmTemporaryAbsenceAddedToRoll.njk
+++ b/server/views/pages/temporaryabsences/confirmTemporaryAbsenceAddedToRoll.njk
@@ -6,7 +6,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
-                titleText: firstName + " " + lastName + " " + "has returned to " + prison.description,
+                titleText: firstName + " " + lastName + " " + "has returned to " + prison.prisonName,
                 html: "Prison number<br><strong>" + prisonNumber | escape + "</strong>",
                 attributes: {
                     'data-qa': 'confirmation-banner'


### PR DESCRIPTION
Get prison name from prison-register rather than welcome-api
Use the prison-register `prison/id/:prisonId `endpoint. 
The only bit of info needed from the object returned from prison-register is the `prisonName`. This is the same as the 'description' previously obtained when calling welcome-api