### PR TITLE
Map 1858 template typescript merge

### DIFF
--- a/helm_deploy/hmpps-welcome-people-into-prison-ui/Chart.yaml
+++ b/helm_deploy/hmpps-welcome-people-into-prison-ui/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-welcome-people-into-prison-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "3.7"
+    version: "3.6"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.11"
+    version: "1.10"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-welcome-people-into-prison-ui/values.yaml
+++ b/helm_deploy/hmpps-welcome-people-into-prison-ui/values.yaml
@@ -55,7 +55,7 @@ generic-service:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
     application-insights:
-      APPINSIGHTS_INSTRUMENTATIONKEY: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+      APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
 
   allowlist:
     groups:


### PR DESCRIPTION
Updated HELM charts.yml to {bellow} following Template Typescript repo & generic-prometheus-alerts set up 
		    version: "3.6"
		    version: "1.10"
As UOF API and LOCA UI have these versions already testd.
Template Typescript is using 3.7 and 1.11.

