### PR TITLE
MAP-1858 HELM upgrade 3.6 and fix to build it

### DIFF
--- a/helm_deploy/hmpps-welcome-people-into-prison-ui/values.yaml
+++ b/helm_deploy/hmpps-welcome-people-into-prison-ui/values.yaml
@@ -40,6 +40,7 @@ generic-service:
 
   namespace_secrets:
     hmpps-welcome-people-into-prison-ui:
+      APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
       API_CLIENT_ID: "API_CLIENT_ID"
       API_CLIENT_SECRET: "API_CLIENT_SECRET"
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
@@ -54,8 +55,6 @@ generic-service:
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
-    application-insights:
-      APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
 
   allowlist:
     groups:


### PR DESCRIPTION
After investigation it has been revealed that deployment claimed about the new APPINSIGHTS_INSTRUMENTATIONKEY resetting as it need some extra change out of the box. 


![image](https://github.com/user-attachments/assets/7ade7c2c-d141-44cf-8529-517905d88e06)
