### PR TITLE
MAP-2071 reduced the data capture to last 6 months

### DIFF
--- a/jobs/eventsJob.ts
+++ b/jobs/eventsJob.ts
@@ -15,7 +15,7 @@ const retriever = new EventsRetriever(hmppsAuthClient, welcomeClientBuilder)
 const pusher = new EventsPusher(config.eventPublishing.serviceAccountKey, config.eventPublishing.spreadsheetId)
 
 const job = async () => {
-  const events = await retriever.retrieveEventsForPastYear()
+  const events = await retriever.retrieveEventsForPastSixMonths()
   await pusher.pushEvents(events)
 }
 

--- a/jobs/eventsRetriever.test.ts
+++ b/jobs/eventsRetriever.test.ts
@@ -20,8 +20,8 @@ describe('test', () => {
       Readable.from('a,b,c\n1,2,3\n4,5,6').pipe(writable)
     })
 
-    const dataStartDate = moment().subtract(1, 'years').startOf('day')
-    const events = await eventsRetriever.retrieveEventsForPastYear()
+    const dataStartDate = moment().subtract(6, 'months').startOf('day')
+    const events = await eventsRetriever.retrieveEventsForPastSixMonths()
 
     expect(events).toStrictEqual([
       ['1', '2', '3'],
@@ -30,7 +30,7 @@ describe('test', () => {
 
     const call = welcomeClient.getEventsCSV.mock.calls[0]
     expect(dataStartDate.isSame(call[1])).toBe(true)
-    expect(call[2]).toBe(365)
+    expect(call[2]).toBe(183)
   })
 
   it('Handles no events', async () => {
@@ -39,7 +39,7 @@ describe('test', () => {
       Readable.from('a,b,c\n').pipe(writable)
     })
 
-    const events = await eventsRetriever.retrieveEventsForPastYear()
+    const events = await eventsRetriever.retrieveEventsForPastSixMonths()
     expect(events).toStrictEqual([])
   })
 })

--- a/jobs/eventsRetriever.ts
+++ b/jobs/eventsRetriever.ts
@@ -10,7 +10,7 @@ export default class EventsRetriever {
     private readonly welcomeClientBuilder: RestClientBuilder<WelcomeClient>
   ) {}
 
-  async retrieveEventsForPastYear(): Promise<string[][]> {
+  async retrieveEventsForPastSixMonths(): Promise<string[][]> {
     const token = await this.hmppsAuthClient.getSystemClientToken()
     const welcomeClient = this.welcomeClientBuilder(token)
     const parser = parse({
@@ -19,14 +19,14 @@ export default class EventsRetriever {
       from: 2,
     })
     const records: string[][] = []
-    const dateOneYearAgo = moment().subtract(1, 'years').startOf('day')
-    welcomeClient.getEventsCSV(parser, dateOneYearAgo, 365)
+    const dateSixMonthsAgo = moment().subtract(6, 'months').startOf('day')
+    welcomeClient.getEventsCSV(parser, dateSixMonthsAgo, 183)
 
     // eslint-disable-next-line no-restricted-syntax
     for await (const record of parser) {
       records.push(record)
     }
-    logger.info(`Retrieved ${records.length} events since ${dateOneYearAgo}`)
+    logger.info(`Retrieved ${records.length} events since ${dateSixMonthsAgo}`)
     return records
   }
 }


### PR DESCRIPTION
Job for the Looker  Studio report crashes because it takes too long to create a report. We are currently getting 1 years worth of the data. Reducing that to 6 months to see if that stops the crash