### PR TITLE
MAPA-218: Send the imprisonment status's fixed from location on confirm

### DIFF
--- a/integration_tests/mockApis/responses/imprisonmentStatuses.ts
+++ b/integration_tests/mockApis/responses/imprisonmentStatuses.ts
@@ -126,6 +126,17 @@ export default [
     ],
   },
   {
+    code: 'repatriation',
+    description: 'Repatriated to this country',
+    imprisonmentStatusCode: 'SENT',
+    fromLocationId: 'FORGN',
+    movementReasons: [
+      {
+        movementReasonCode: 'I',
+      },
+    ],
+  },
+  {
     code: 'temporary-stay',
     description: 'Temporary stay enroute to another establishment',
     imprisonmentStatusCode: 'SENT',

--- a/server/@types/welcome/index.d.ts
+++ b/server/@types/welcome/index.d.ts
@@ -124,6 +124,7 @@ declare module 'welcome' {
       imprisonmentStatusCode: string
       secondLevelTitle?: string
       secondLevelValidationMessage?: string
+      fromLocationId?: string
       movementReasons: { description?: string; movementReasonCode: string }[]
     }
     Prison: {

--- a/server/data/__testutils/testObjects.ts
+++ b/server/data/__testutils/testObjects.ts
@@ -238,10 +238,18 @@ export const createImprisonmentStatuses = (): ImprisonmentStatus[] => [
       { description: 'Partly suspended sentence', movementReasonCode: 'P' },
     ],
   },
+  {
+    code: 'repatriation',
+    description: 'Repatriated to this country',
+    imprisonmentStatusCode: 'SENT',
+    fromLocationId: 'FORGN',
+    movementReasons: [{ movementReasonCode: 'I' }],
+  },
 ]
 
 export const statusWithSingleReason = createImprisonmentStatuses().find(s => s.code === 'on-remand')
 export const statusWithManyReasons = createImprisonmentStatuses().find(s => s.code === 'determinate-sentence')
+export const statusWithFromLocation = createImprisonmentStatuses().find(s => s.code === 'repatriation')
 
 export const createMatchCriteria = (): PotentialMatchCriteria => ({
   firstName: 'James',
@@ -278,7 +286,7 @@ export const createNewArrival = ({
   movementReasonCode = 'N',
   prisonNumber = 'A1234AA',
   expected = true,
-} = {}): NewArrival => ({
+}: Partial<NewArrival> = {}): NewArrival => ({
   firstName,
   lastName,
   dateOfBirth,

--- a/server/routes/bookedtoday/arrivals/confirmArrival/imprisonmentStatusesController.test.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/imprisonmentStatusesController.test.ts
@@ -7,6 +7,7 @@ import { State } from '../state'
 import {
   createImprisonmentStatuses,
   createNewArrival,
+  statusWithFromLocation,
   statusWithManyReasons,
   statusWithSingleReason,
 } from '../../../../data/__testutils/testObjects'
@@ -110,6 +111,25 @@ describe('/imprisonment-status', () => {
             code: statusWithSingleReason.code,
             imprisonmentStatus: statusWithSingleReason.imprisonmentStatusCode,
             movementReasonCode: statusWithSingleReason.movementReasons[0].movementReasonCode,
+          })
+        })
+    })
+
+    it('should store the from location when the status has a fixed one', () => {
+      imprisonmentStatusesService.getImprisonmentStatus.mockResolvedValue(statusWithFromLocation)
+
+      return request(app)
+        .post('/prisoners/12345-67890/imprisonment-status')
+        .send({ imprisonmentStatus: statusWithFromLocation.code })
+        .expect(302)
+        .expect(res => {
+          expectSettingCookie(res, State.newArrival).toStrictEqual({
+            ...newArrival,
+            expected: 'true',
+            code: statusWithFromLocation.code,
+            imprisonmentStatus: statusWithFromLocation.imprisonmentStatusCode,
+            movementReasonCode: statusWithFromLocation.movementReasons[0].movementReasonCode,
+            fromLocationId: 'FORGN',
           })
         })
     })

--- a/server/routes/bookedtoday/arrivals/confirmArrival/imprisonmentStatusesController.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/imprisonmentStatusesController.ts
@@ -37,6 +37,7 @@ export default class ImprisonmentStatusesController {
           code: selectedImprisonmentStatus.code,
           imprisonmentStatus: selectedImprisonmentStatus.imprisonmentStatusCode,
           movementReasonCode: selectedImprisonmentStatus.movementReasons[0].movementReasonCode,
+          fromLocationId: selectedImprisonmentStatus.fromLocationId,
         })
 
         return res.redirect(`/prisoners/${id}/check-answers`)

--- a/server/routes/bookedtoday/arrivals/confirmArrival/movementReasonsController.ts
+++ b/server/routes/bookedtoday/arrivals/confirmArrival/movementReasonsController.ts
@@ -41,6 +41,7 @@ export default class MovementReasonsController {
         code: selectedImprisonmentStatus.code,
         imprisonmentStatus: selectedImprisonmentStatus.imprisonmentStatusCode,
         movementReasonCode: movementReason,
+        fromLocationId: selectedImprisonmentStatus.fromLocationId,
       })
 
       return res.redirect(`/prisoners/${id}/check-answers`)

--- a/server/routes/bookedtoday/arrivals/state.test.ts
+++ b/server/routes/bookedtoday/arrivals/state.test.ts
@@ -13,6 +13,7 @@ describe('NewArrivalCodec', () => {
       code: 'on remand',
       imprisonmentStatus: 'RX',
       movementReasonCode: 'N',
+      fromLocationId: 'FORGN',
       expected: 'true',
     })
 
@@ -26,6 +27,7 @@ describe('NewArrivalCodec', () => {
       code: 'on remand',
       imprisonmentStatus: 'RX',
       movementReasonCode: 'N',
+      fromLocationId: 'FORGN',
       expected: true,
     })
   })
@@ -41,6 +43,7 @@ describe('NewArrivalCodec', () => {
       code: 'on remand',
       imprisonmentStatus: 'RX',
       movementReasonCode: 'N',
+      fromLocationId: 'FORGN',
       expected: 'false',
     })
 
@@ -54,6 +57,7 @@ describe('NewArrivalCodec', () => {
       code: 'on remand',
       imprisonmentStatus: 'RX',
       movementReasonCode: 'N',
+      fromLocationId: 'FORGN',
       expected: false,
     })
   })
@@ -77,6 +81,7 @@ describe('NewArrivalCodec', () => {
       code: undefined,
       imprisonmentStatus: undefined,
       movementReasonCode: undefined,
+      fromLocationId: undefined,
     })
   })
 
@@ -91,6 +96,7 @@ describe('NewArrivalCodec', () => {
       code: 'on remand',
       imprisonmentStatus: 'RX',
       movementReasonCode: 'N',
+      fromLocationId: 'FORGN',
       expected: true,
     })
 
@@ -104,6 +110,7 @@ describe('NewArrivalCodec', () => {
       code: 'on remand',
       imprisonmentStatus: 'RX',
       movementReasonCode: 'N',
+      fromLocationId: 'FORGN',
       expected: 'true',
     })
   })

--- a/server/routes/bookedtoday/arrivals/state.ts
+++ b/server/routes/bookedtoday/arrivals/state.ts
@@ -12,6 +12,7 @@ export type NewArrival = {
   code?: string
   imprisonmentStatus?: string
   movementReasonCode?: string
+  fromLocationId?: string
   expected: boolean
 }
 
@@ -27,6 +28,7 @@ export const NewArrivalCodec: Codec<NewArrival> = {
     ...(value.code !== undefined && { code: value.code }),
     ...(value.imprisonmentStatus !== undefined && { imprisonmentStatus: value.imprisonmentStatus }),
     ...(value.movementReasonCode !== undefined && { movementReasonCode: value.movementReasonCode }),
+    ...(value.fromLocationId !== undefined && { fromLocationId: value.fromLocationId }),
   }),
 
   read(record: Record<string, unknown>): NewArrival {
@@ -38,6 +40,7 @@ export const NewArrivalCodec: Codec<NewArrival> = {
       'code',
       'imprisonmentStatus',
       'movementReasonCode',
+      'fromLocationId',
     ])
 
     return {
@@ -51,6 +54,7 @@ export const NewArrivalCodec: Codec<NewArrival> = {
       code: record.code,
       imprisonmentStatus: record.imprisonmentStatus,
       movementReasonCode: record.movementReasonCode,
+      fromLocationId: record.fromLocationId,
     }
   },
 }

--- a/server/services/expectedArrivalsService.test.ts
+++ b/server/services/expectedArrivalsService.test.ts
@@ -312,6 +312,29 @@ describe('Expected arrivals service', () => {
       })
     })
 
+    it("prefers the move's own from location over the one fixed by the imprisonment status", async () => {
+      welcomeClient.confirmExpectedArrival.mockResolvedValue({ prisonNumber: 'A1234AA', location: 'AA-1' })
+
+      await service.confirmArrival('MDI', username, '12345-67890', { ...newArrival, fromLocationId: 'FORGN' })
+
+      expect(welcomeClient.confirmExpectedArrival).toBeCalledWith(
+        '12345-67890',
+        expect.objectContaining({ fromLocationId: 'REDCC' }),
+      )
+    })
+
+    it('falls back to the from location fixed by the imprisonment status', async () => {
+      welcomeClient.getArrival.mockResolvedValue({ ...createArrival(), fromLocationId: undefined })
+      welcomeClient.confirmExpectedArrival.mockResolvedValue({ prisonNumber: 'A1234AA', location: 'AA-1' })
+
+      await service.confirmArrival('MDI', username, '12345-67890', { ...newArrival, fromLocationId: 'FORGN' })
+
+      expect(welcomeClient.confirmExpectedArrival).toBeCalledWith(
+        '12345-67890',
+        expect.objectContaining({ fromLocationId: 'FORGN' }),
+      )
+    })
+
     it('raises event when confirmation was successful', async () => {
       welcomeClient.confirmExpectedArrival.mockResolvedValue({ prisonNumber: 'A1234AA', location: 'AA-1' })
 
@@ -359,6 +382,16 @@ describe('Expected arrivals service', () => {
         movementReasonCode: 'N',
         prisonNumber: 'A1234AA',
       })
+    })
+
+    it('sends the from location fixed by the imprisonment status', async () => {
+      welcomeClient.confirmUnexpectedArrival.mockResolvedValue(arrivalResponse)
+
+      await service.confirmArrival('MDI', username, '12345-67890', { ...newArrival, fromLocationId: 'FORGN' })
+
+      expect(welcomeClient.confirmUnexpectedArrival).toBeCalledWith(
+        expect.objectContaining({ fromLocationId: 'FORGN' }),
+      )
     })
 
     it('raises event when confirmation was successful', async () => {

--- a/server/services/expectedArrivalsService.ts
+++ b/server/services/expectedArrivalsService.ts
@@ -158,7 +158,9 @@ export default class ExpectedArrivalsService {
       prisonId,
       imprisonmentStatus: arrival.imprisonmentStatus,
       movementReasonCode: arrival.movementReasonCode,
-      fromLocationId: data.fromLocationId,
+      // The move's own origin is the more accurate record, so it wins over any
+      // fixed origin the selected imprisonment status carries
+      fromLocationId: data.fromLocationId ?? arrival.fromLocationId,
       prisonNumber: arrival.prisonNumber,
     })
 
@@ -188,7 +190,7 @@ export default class ExpectedArrivalsService {
       prisonId,
       imprisonmentStatus: arrival.imprisonmentStatus,
       movementReasonCode: arrival.movementReasonCode,
-      fromLocationId: undefined,
+      fromLocationId: arrival.fromLocationId,
       prisonNumber: arrival.prisonNumber,
     })
 


### PR DESCRIPTION
## Why

Supports the new "Repatriated to this country" admission type added in [hmpps-welcome-people-into-prison-api#360](https://github.com/ministryofjustice/hmpps-welcome-people-into-prison-api/pull/360).

HMP Wandsworth receive British citizens repatriated or extradited back into the UK. In NOMIS they have always recorded these with movement reason "Imprisonment without option of a fine" **and** a point of origin of the agency location "Repatriated To This Country" (`FORGN`).

WPIP could do the movement reason but not the point of origin. `confirmUnexpectedArrival` hardcoded `fromLocationId: undefined`, so every manually confirmed arrival — the path Wandsworth actually use — landed in NOMIS as coming from `OUT`.

The radio itself needs no UI change; the list is rendered straight from `GET /imprisonment-statuses`. This PR is only the plumbing to carry the status's fixed origin through to the confirm call.

## What

- `fromLocationId` added to the `ImprisonmentStatus` type and to `NewArrival` state (type, codec `write`, `read` allowlist and returned object).
- Both status controllers now copy `fromLocationId` from the selected status into state, on the single-reason and multi-reason paths.
- `confirmUnexpectedArrival` sends it instead of always sending nothing.
- `confirmExpectedArrival` uses `data.fromLocationId ?? arrival.fromLocationId`.

**On that fallback:** for an expected arrival BaSM already knows where the person physically travelled from, and that is the more accurate record, so it wins. The status-supplied default only fills the gap. Wandsworth's case is the manual path, which has no BaSM value, so it always gets `FORGN`.

## Testing

`npm test` (728 pass) and `npm run lint` clean. New coverage for: the status controller storing the fixed origin, the unexpected-arrival confirm forwarding it, and both branches of the expected-arrival precedence rule.

Cypress not run locally. Existing specs select radios by code so the extra fixture option is inert for them.

## Notes

- The API PR must merge first — this is inert without it.
- `integration_tests/mockApis/responses/imprisonmentStatuses.ts` has drifted from the API (old `SENT`/`RX`/`JR` codes, and it still calls the transfer entry "Transfer from another establishment"). I added the new entry using the file's existing convention rather than refreshing it, because several cypress specs assert `imprisonmentStatus: 'SENT'` in the confirm payload and a wholesale refresh would break them. Worth a separate ticket.

## Before release

Verify end to end in dev/preprod that a manual arrival with this option produces a NOMIS record showing movement reason "Imprisonment without option of a fine" and point of origin "Repatriated To This Country".
